### PR TITLE
Integrate ES index population mechanism

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,2 @@
 ES_PORT=
+SAMPLE_URL=

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ WORKDIR /app/
 COPY --from=build /home/gradle/tla/build/libs/*.jar /app/tla-web-backend.jar
 
 ARG es_port
+ARG es_host
 ENV ES_PORT ${es_port}
+ENV ES_HOST ${es_host}
 EXPOSE 8090
 ENTRYPOINT ["java", "-jar", "/app/tla-web-backend.jar"]

--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 ![LINE](https://img.shields.io/badge/line--coverage-51%25-orange.svg)
 ![METHOD](https://img.shields.io/badge/method--coverage-47%25-orange.svg)
 
-You can check for the newest version of package dependencies by running:
+Initialize the project by creating a `.env` file with at least the corpus data source specified:
 
-    ./gradlew dependencyUpdates
+    SAMPLE_URL=http://example.org/sample.tar.gz
 
 
 Run a dockerized setup using Docker Compose:
 
-    docker-compose up -d
+    docker-compose up -d elasticsearch
+    ./gradlew downloadSample
+    docker-compose up -d backend
 
 
 In order to only use the Elasticsearch container and run the application via gradle:
 
     docker-compose up -d elasticsearch
-    ./gradlew bootRun
+    ./gradlew populate bootRun
 
 *Note:* You can configure the Elasticsearch HTTP port to which the application will try to connect.
 Both the Docker Compose configuration and the `bootRun` and `test` gradle tasks are going to read
@@ -36,3 +38,10 @@ There is a gradle task for populating the backend app's elasticsearch indices wi
 from a URL specified via the `SAMPLE_URL` environment variable:
 
     ./gradlew populate
+
+
+You can check for the newest version of package dependencies by running:
+
+    ./gradlew dependencyUpdates
+
+

--- a/README.md
+++ b/README.md
@@ -22,10 +22,17 @@ Both the Docker Compose configuration and the `bootRun` and `test` gradle tasks 
 it from the local `.env` file.
 
 When running the application using the  `bootRun` task, comma-separated arguments can be passed via
-`args` property like this:
+`args` property in the following ways:
 
-    ./gradlew bootRun -Pargs=--data-file=sample.tar.gz,--foo=bar
+    ./gradlew bootRun --Pargs=--data-file=sample.tar.gz,--foo=bar
+    ./gradlew bootRun --args="--data-file=sample.tar.gz --foo=bar"
+
 
 Populate database with a corpus dump and shut down after:
 
-    ./gradlew bootRun -Pargs=--date-file=sample.tar.gz,--shutdown
+    ./gradlew bootRun --args="--date-file=sample.tar.gz --shutdown"
+
+There is a gradle task for populating the backend app's elasticsearch indices with corpus data obtained
+from a URL specified via the `SAMPLE_URL` environment variable:
+
+    ./gradlew populate

--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ In order to only use the Elasticsearch container and run the application via gra
 *Note:* You can configure the Elasticsearch HTTP port to which the application will try to connect.
 Both the Docker Compose configuration and the `bootRun` and `test` gradle tasks are going to read
 it from the local `.env` file.
+
+When running the application using the  `bootRun` task, comma-separated arguments can be passed via
+`args` property like this:
+
+    ./gradlew bootRun -Pargs=--data-file=sample.tar.gz,--foo=bar
+
+Populate database with a corpus dump:
+
+    ./gradlew bootRun -Pargs=--date-file=sample.tar.gz

--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ When running the application using the  `bootRun` task, comma-separated argument
 
     ./gradlew bootRun -Pargs=--data-file=sample.tar.gz,--foo=bar
 
-Populate database with a corpus dump:
+Populate database with a corpus dump and shut down after:
 
-    ./gradlew bootRun -Pargs=--date-file=sample.tar.gz
+    ./gradlew bootRun -Pargs=--date-file=sample.tar.gz,--shutdown

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'application'
     id 'maven-publish'
     id 'co.uzzu.dotenv.gradle' version '1.0.2'
+    id 'de.undercouch.download' version '4.0.4'
     id 'org.springframework.boot' version '2.2.6.RELEASE'
     id 'com.github.ben-manes.versions' version '0.28.0'
     id 'com.github.dawnwords.jacoco.badge' version '0.2.0'
@@ -89,3 +90,18 @@ bootRun {
     environment "ES_PORT", env.ES_PORT.orElse("9200")
 }
 
+task downloadSample(type: Download) {
+    group = 'Init'
+    description = 'Download corpus sample file'
+    src env.SAMPLE_URL.orElse("http://")
+    dest new File('sample.tar.gz')
+    onlyIfModified true
+}
+
+task populate {
+    group = 'Init'
+    description = 'Download corpus sample and ingest into database backend'
+    bootRun.args = ['--data-file=sample.tar.gz', '--shutdown']
+    dependsOn 'downloadSample'
+    finalizedBy 'bootRun'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 
     implementation 'com.github.jkatzwinkel:tla-common:master-SNAPSHOT'
     implementation 'org.modelmapper:modelmapper:2.3.7'
+    implementation 'org.apache.commons:commons-compress:1.20'
 
     implementation 'org.springframework.data:spring-data-elasticsearch:3.2.4.RELEASE'
     implementation 'org.springframework.boot:spring-boot-starter-web:2.3.0.M1'
@@ -82,5 +83,9 @@ jacocoTestReport {
 }
 
 bootRun {
+    if (project.hasProperty('args')) {
+        args project.args.split(',')
+    }
     environment "ES_PORT", env.ES_PORT.orElse("9200")
 }
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,6 @@ services:
             context: https://github.com/jkatzwinkel/tla-populate.git
             args:
                 - SAMPLE_URL=${SAMPLE_URL}
-                - BACKEND_URL=http://backend:8090
         command: http://localhost:8090
         tty: true
         network_mode: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,15 +13,28 @@ services:
         stdin_open: true
         tty: true
 
-    app:
+    backend:
         depends_on:
             - elasticsearch
         build:
             context: .
             args:
                 - es_port=${ES_PORT}
+                - es_host=localhost
         ports:
             - 8090:8090
+        tty: true
+        network_mode: host
+
+    tla-populate:
+        depends_on:
+            - backend
+        build:
+            context: https://github.com/jkatzwinkel/tla-populate.git
+            args:
+                - SAMPLE_URL=${SAMPLE_URL}
+                - BACKEND_URL=http://backend:8090
+        command: http://localhost:8090
         tty: true
         network_mode: host
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,15 +25,8 @@ services:
             - 8090:8090
         tty: true
         network_mode: host
+        volumes:
+            - ${PWD}/sample.tar.gz:/app/sample.tar.gz
+        command: "--data-file=sample.tar.gz"
 
-    tla-populate:
-        depends_on:
-            - backend
-        build:
-            context: https://github.com/jkatzwinkel/tla-populate.git
-            args:
-                - SAMPLE_URL=${SAMPLE_URL}
-        command: http://localhost:8090
-        tty: true
-        network_mode: host
 

--- a/src/main/java/tla/backend/App.java
+++ b/src/main/java/tla/backend/App.java
@@ -8,6 +8,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
 import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +24,9 @@ public class App implements ApplicationRunner {
 
     @Autowired
     private RepoPopulator repoPopulator;
+
+    @Autowired
+    private ApplicationContext applicationContext;
 
     public static void main(String[] args) {
         log.info("startup TLA backend app");
@@ -43,5 +47,17 @@ public class App implements ApplicationRunner {
                 args.getOptionValues("data-file")
             );
         }
+        if (args.containsOption("shutdown")) {
+            shutdown();
+        }
+    }
+
+    public void shutdown() {
+        System.exit(
+            SpringApplication.exit(
+                applicationContext,
+                () -> 0
+            )
+        );
     }
 }

--- a/src/main/java/tla/backend/App.java
+++ b/src/main/java/tla/backend/App.java
@@ -1,5 +1,8 @@
 package tla.backend;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
@@ -9,19 +12,36 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
+import lombok.extern.slf4j.Slf4j;
+import tla.backend.es.repo.RepoPopulator;
+
+@Slf4j
 @Configuration
 @ComponentScan
-@EnableAutoConfiguration(exclude = {ElasticsearchDataAutoConfiguration.class})
-public class App {
+@EnableAutoConfiguration(exclude = { ElasticsearchDataAutoConfiguration.class })
+public class App implements ApplicationRunner {
 
-	public static void main(String[] args) {
-		SpringApplication.run(App.class, args);
-	}
+    @Autowired
+    private RepoPopulator repoPopulator;
+
+    public static void main(String[] args) {
+        log.info("startup TLA backend app");
+        SpringApplication.run(App.class, args);
+    }
 
     @Bean
     public ServletWebServerFactory servletWebServerFactory() {
         return new TomcatServletWebServerFactory(8090);
     }
 
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        log.info("process command line args:");
+        log.info(String.join(", ", args.getOptionNames()));
+        if (args.containsOption("data-file")) {
+            repoPopulator.ingestTarFile(
+                args.getOptionValues("data-file")
+            );
+        }
+    }
 }
-

--- a/src/main/java/tla/backend/api/LemmaController.java
+++ b/src/main/java/tla/backend/api/LemmaController.java
@@ -11,7 +11,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -20,7 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.extern.slf4j.Slf4j;
 import tla.backend.es.model.LemmaEntity;
 import tla.backend.es.model.OccurrenceEntity;
-import tla.backend.es.model.TLAEntity;
 import tla.backend.es.repo.LemmaRepo;
 import tla.backend.service.LemmaService;
 import tla.domain.dto.LemmaDto;
@@ -56,21 +54,6 @@ public class LemmaController {
             repo.count(),
             HttpStatus.OK
         );
-    }
-
-    /**
-     * TODO this is just for debugging temporarily
-     */
-    @RequestMapping(method = RequestMethod.GET, value = "/find/{id}")
-    public ResponseEntity<LemmaEntity> findLemmaById(@PathVariable String id) throws Exception {
-        TLAEntity result = queryService.retrieveSingleBTSDoc("BTSLemmaEntry", id);
-        if (result instanceof LemmaEntity) {
-            return new ResponseEntity<LemmaEntity>(
-                (LemmaEntity) result,
-                HttpStatus.OK
-            );
-        }
-        throw new ObjectNotFoundException();
     }
 
     @RequestMapping(method = RequestMethod.GET, value = "/get/{id}")
@@ -138,23 +121,6 @@ public class LemmaController {
         return new ResponseEntity<List<String>>(
             result,
             HttpStatus.OK
-        );
-
-    }
-
-    @RequestMapping(method = RequestMethod.POST, value = "/post")
-    public ResponseEntity<LemmaEntity> postLemma(@RequestBody LemmaEntity lemma) {
-        return new ResponseEntity<LemmaEntity>(
-            repo.save(lemma),
-            HttpStatus.CREATED
-        );
-    }
-
-    @RequestMapping(method = RequestMethod.POST, value = "/batch")
-    public ResponseEntity<Iterable<LemmaEntity>> postLemma(@RequestBody Iterable<LemmaEntity> lemmata) {
-        return new ResponseEntity<Iterable<LemmaEntity>>(
-            repo.saveAll(lemmata),
-            HttpStatus.CREATED
         );
     }
 

--- a/src/main/java/tla/backend/api/OccurrenceController.java
+++ b/src/main/java/tla/backend/api/OccurrenceController.java
@@ -12,7 +12,6 @@ import org.springframework.data.elasticsearch.core.query.SearchQuery;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -111,14 +110,6 @@ public class OccurrenceController {
         return new ResponseEntity<Long>(
             repo.count(),
             HttpStatus.OK
-        );
-    }
-
-    @RequestMapping(method = RequestMethod.POST, value = "/batch")
-    public ResponseEntity<Iterable<OccurrenceEntity>> postLemma(@RequestBody Iterable<OccurrenceEntity> lemmata) {
-        return new ResponseEntity<Iterable<OccurrenceEntity>>(
-            repo.saveAll(lemmata),
-            HttpStatus.CREATED
         );
     }
 

--- a/src/main/java/tla/backend/api/TextController.java
+++ b/src/main/java/tla/backend/api/TextController.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,12 +33,4 @@ public class TextController {
         throw new ObjectNotFoundException();
     }
 
-    @RequestMapping(method = RequestMethod.POST, value = "/batch")
-    public ResponseEntity<Iterable<TextEntity>> postEntries(@RequestBody Iterable<TextEntity> entries) {
-        return new ResponseEntity<Iterable<TextEntity>>(
-            repo.saveAll(entries),
-            HttpStatus.CREATED
-        );
-    }
-    
 }

--- a/src/main/java/tla/backend/api/ThesaurusController.java
+++ b/src/main/java/tla/backend/api/ThesaurusController.java
@@ -6,7 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,19 +33,4 @@ public class ThesaurusController {
         throw new ObjectNotFoundException();
     }
 
-    @RequestMapping(method = RequestMethod.POST, value = "/post")
-    public ResponseEntity<ThsEntryEntity> postEntry(@RequestBody ThsEntryEntity entry) {
-        return new ResponseEntity<ThsEntryEntity>(
-            repo.save(entry),
-            HttpStatus.CREATED
-        );
-    }
-
-    @RequestMapping(method = RequestMethod.POST, value = "/batch")
-    public ResponseEntity<Iterable<ThsEntryEntity>> postEntries(@RequestBody Iterable<ThsEntryEntity> entries) {
-        return new ResponseEntity<Iterable<ThsEntryEntity>>(
-            repo.saveAll(entries),
-            HttpStatus.CREATED
-        );
-    }
 }

--- a/src/main/java/tla/backend/config/ApplicationProperties.java
+++ b/src/main/java/tla/backend/config/ApplicationProperties.java
@@ -15,5 +15,6 @@ public class ApplicationProperties {
     @Data
     public static class ElasticsearchProperties {
         private int port;
+        private String host;
     }
 }

--- a/src/main/java/tla/backend/es/model/OccurrenceEntity.java
+++ b/src/main/java/tla/backend/es/model/OccurrenceEntity.java
@@ -47,6 +47,8 @@ public class OccurrenceEntity implements Indexable {
 
     @Data
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Flexion {
 
         private String glossing;
@@ -59,6 +61,8 @@ public class OccurrenceEntity implements Indexable {
 
     @Data
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Lemmatization {
 
         private String pos;
@@ -70,6 +74,8 @@ public class OccurrenceEntity implements Indexable {
 
     @Data
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class OccurrenceLocation {
 
         private String line;

--- a/src/main/java/tla/backend/es/repo/RepoConfig.java
+++ b/src/main/java/tla/backend/es/repo/RepoConfig.java
@@ -35,13 +35,17 @@ public class RepoConfig extends AbstractElasticsearchConfiguration {
     @Override
     public RestHighLevelClient elasticsearchClient() {
         log.info
-            ("create elasticsearch client for local instance at port {}",
+            ("create elasticsearch client for local instance at {}:{}",
+            env.getProperty("tla.es.host"),
             env.getProperty("tla.es.port")
         );
         return RestClients.create(
             ClientConfiguration.create(
                 InetSocketAddress.createUnresolved(
-                    "localhost",
+                    env.getProperty(
+                        "tla.es.host",
+                        "localhost"
+                    ),
                     Integer.parseInt(
                         env.getProperty(
                             "tla.es.port",

--- a/src/main/java/tla/backend/es/repo/RepoConfig.java
+++ b/src/main/java/tla/backend/es/repo/RepoConfig.java
@@ -57,4 +57,9 @@ public class RepoConfig extends AbstractElasticsearchConfiguration {
         ).rest();
     }
 
+    @Bean
+    public RepoPopulator repoPopulator() {
+        return new RepoPopulator();
+    }
+
 }

--- a/src/main/java/tla/backend/es/repo/RepoPopulator.java
+++ b/src/main/java/tla/backend/es/repo/RepoPopulator.java
@@ -1,0 +1,174 @@
+package tla.backend.es.repo;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.elasticsearch.core.EntityMapper;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import lombok.extern.slf4j.Slf4j;
+import tla.backend.es.model.Indexable;
+import tla.backend.es.model.LemmaEntity;
+import tla.backend.es.model.OccurrenceEntity;
+import tla.backend.es.model.TextEntity;
+import tla.backend.es.model.ThsEntryEntity;
+
+@Slf4j
+public class RepoPopulator {
+
+    private class RepoBatchIngestor<T extends ElasticsearchRepository<S, String>, S extends Indexable> {
+
+        private List<S> batch;
+        private T repo;
+        private Class<S> modelClass;
+        private int count;
+
+        public RepoBatchIngestor(T repo, Class<S> modelClass) {
+            this.repo = repo;
+            log.info("modelclass: {}, repo: {}", modelClass.getName(), repo);
+            this.modelClass = modelClass;
+            this.batch = new ArrayList<>();
+            this.count = 0;
+        }
+
+        public void add(S doc) {
+            this.batch.add(doc);
+            if (this.batch.size() > 1000) {
+                this.ingest();
+            }
+        }
+
+        public void add(String json) {
+            try {
+                S doc = mapper.mapToObject(
+                    json,
+                    this.modelClass
+                );
+                this.add(doc);
+            } catch (IOException e) {
+                log.error(
+                    String.format(
+                        "ingestor could not instantiate %s class from %s",
+                        this.modelClass.getName(),
+                        json.subSequence(0, 30)
+                    ),
+                    e
+                );
+            }
+        }
+
+        public void ingest() {
+            try {
+                this.repo.saveAll(this.batch);
+            } catch (Exception e) {
+                log.error(
+                    String.format(
+                        "%s ingestor could not save %d docs!",
+                        this.modelClass.getName(),
+                        this.batch.size()
+                    ),
+                    e
+                );
+            } finally {
+                this.count += this.batch.size();
+                this.batch.clear();
+            }
+        }
+    }
+
+    @Autowired
+    private EntityMapper mapper;
+
+    @Autowired
+    private LemmaRepo lemmaRepo;
+
+    @Autowired
+    private TextRepo textRepo;
+
+    @Autowired
+    private ThesaurusRepo thesaurusRepo;
+
+    @Autowired
+    private OccurrenceRepo occurrenceRepo;
+
+    private static Map<String, RepoBatchIngestor<?,?>> INGESTORS;
+
+    public void ingestTarFile(List<String> filenames) throws IOException {
+        INGESTORS = Map.of(
+            "text", new RepoBatchIngestor<ElasticsearchRepository<TextEntity,String>,TextEntity>(textRepo, TextEntity.class),
+            "lemma", new RepoBatchIngestor<ElasticsearchRepository<LemmaEntity,String>,LemmaEntity>(lemmaRepo, LemmaEntity.class),
+            "ths", new RepoBatchIngestor<ElasticsearchRepository<ThsEntryEntity,String>,ThsEntryEntity>(thesaurusRepo, ThsEntryEntity.class),
+            "occurrence", new RepoBatchIngestor<ElasticsearchRepository<OccurrenceEntity,String>,OccurrenceEntity>(occurrenceRepo, OccurrenceEntity.class)
+        );
+        log.info("process tar file {}", String.join(", ", filenames));
+        if (filenames.size() == 1) {
+            String filename = filenames.get(0);
+            try (TarArchiveInputStream input = new TarArchiveInputStream(
+                    new GzipCompressorInputStream(
+                        new FileInputStream(filename)
+                    )
+                )
+            ) {
+                processTarArchive(input);
+            } catch (FileNotFoundException e) {
+                log.error(
+                    String.format("file not found: %s", filename),
+                    e
+                );
+            } catch (IOException e) {
+                log.error(
+                    String.format("error during processing tar archive %s", filename),
+                    e
+                );
+            }
+        }
+        INGESTORS = null;
+    }
+
+    private void processTarArchive(TarArchiveInputStream input) throws IOException {
+        TarArchiveEntry archiveEntry;
+        RepoBatchIngestor<? extends ElasticsearchRepository<? extends Indexable, String>, ? extends Indexable> batchIngestor = null;
+        while ((archiveEntry = input.getNextTarEntry()) != null) {
+            if (archiveEntry.isDirectory()) {
+                String[] segments = archiveEntry.getName().split("/");
+                String typeId = segments[segments.length - 1];
+                if (INGESTORS.containsKey(typeId)) {
+                    log.info("directory {}", archiveEntry.getName());
+                    batchIngestor = INGESTORS.get(typeId);
+                } else {
+                    batchIngestor = null;
+                }
+            } else {
+                if (input.canReadEntryData(archiveEntry)) {
+                    String json = new String(input.readAllBytes());
+                    if (batchIngestor != null) {
+                        batchIngestor.add(json);
+                    }
+                } else {
+                    log.warn("archived file {} not readable", archiveEntry.getName());
+                }
+            }
+        }
+        flushIngestors();
+    }
+
+    private void flushIngestors() {
+        for (RepoBatchIngestor<? extends ElasticsearchRepository<? extends Indexable, String>, ? extends Indexable> batchIngestor : INGESTORS.values()) {
+            batchIngestor.ingest();
+            log.info(
+                "ingested {} documents of type {}",
+                batchIngestor.count,
+                batchIngestor.modelClass.getName()
+            );
+        }
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,4 @@ server:
 tla:
     es:
         port: ${ES_PORT:9200}
+        host: ${ES_HOST:localhost}

--- a/src/test/java/tla/backend/api/LemmaControllerTest.java
+++ b/src/test/java/tla/backend/api/LemmaControllerTest.java
@@ -20,10 +20,8 @@ import tla.backend.es.model.EditorInfo;
 import tla.backend.service.LemmaService;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -76,35 +74,6 @@ public class LemmaControllerTest extends AbstractMockMvcTest {
             () -> assertEquals(l1.hashCode(), l2.hashCode(), "hashCode should return equals"),
             () -> assertNotNull(l2.getWords().get(0).getTranscription(), "expect word transcription")
         );
-    }
-
-    @Test
-    void postLemma() throws Exception {
-        when(repo.save(any()))
-            .thenReturn(
-                LemmaEntity.builder()
-                    .id("1")
-                    .eclass("BTSLemmaEntry")
-                    .sortKey("A")
-                    .build()
-                );
-        LemmaEntity l = repo.save(
-            LemmaEntity.builder()
-                .id("2")
-                .eclass("BTSLemmaEntry")
-                .build()
-            );
-        assertEquals("1", l.getId(), "whatever is being saved by mock up repo, it should always return a lemma with ID '1'");
-        mockMvc.perform(
-            post("/lemma/post")
-                .contentType("application/json")
-                .content("{\"id\":\"1\",\"sort_string\":\"A\"}")
-        )
-            .andExpect(
-                status().isCreated()
-            )
-            .andExpect(jsonPath("$.id").value("1"))
-            .andExpect(jsonPath("$.sortKey").value("A"));
     }
 
     @Test


### PR DESCRIPTION
For the sake of frictionlesz automated setup/installation via docker, at least one method for loading corpus data into the backend's Elasticsearch index repositories is needed. There are multiple options, including:

- Batch-upload corpus documents from seperate JSON files into backend app via POST requests, as implemented in https://github.com/JKatzwinkel/tla-populate and integrated in 29e8820ffdf5c1696a2f403c00314709aecf79d8
- Batch-upload corpus documents from JSON files directly into ES via POST requests, after index mappings/settings have been created in an initial backend app run (not implemented)
- Batch document ingestion from TAR-archive using spring data repos from inside the backend app, triggered by command-line arguments, as implemented in 6ded8b4, 1b0b467, 27e5f89 ...

The lattermost approach seems preferable because:

- implemented inside the app without the need of extra services/images to be built
- fewer docker stunts required, can rely more on gradle as our primary build tool, i.e. e.g.:
  - hopefully maybe no need for `network_mode: host` which seems to not be supported on windows :disappointed: 
- streams documents from TAR archive whereas previous solutions read from unpacked archive
- lesz of a hassle in general

Frontend app docker setup maybe can use the backend app image in two succinct services, the first of which shoehorning the corpus data TAR file into the container via `volumes` and overriding/customizing the entry point command using `command: "--data-file=sample.tar.gz --shutdown`.