### PR TITLE
Easier deployment to docker containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
-bin
+bin/main
+bin/test
 build
 docker-compose.yml
 .dockerignore

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,7 +15,7 @@ jobs:
         java-version: 11
 
     - name: Set up Elasticsearch container
-      run: docker-compose up -d elasticsearch
+      run: docker-compose up -d es
       env:
         ES_PORT: 9200
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@
 .settings
 app.log
 app.log.*
-bin
+bin/main/
+bin/test/
 build
 sample.tar.gz
 settings.gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,15 @@ FROM gradle:6.3-jdk11 AS build
 COPY --chown=gradle:gradle . /home/gradle/tla
 WORKDIR /home/gradle/tla
 
-RUN gradle bootJar --no-daemon
+RUN gradle bootJar --no-daemon && \
+    mv build/libs/*.jar bin/run/tla-backend.jar
 
 
-FROM openjdk:11-jre-slim
+FROM openjdk:16-jdk-alpine3.12
 
 RUN mkdir /app
 WORKDIR /app/
-COPY --from=build /home/gradle/tla/build/libs/*.jar /app/tla-web-backend.jar
+COPY --from=build /home/gradle/tla/bin/run/ /app/
 
-ARG es_port
-ARG es_host
-ENV ES_PORT ${es_port}
-ENV ES_HOST ${es_host}
 EXPOSE 8090
-ENTRYPOINT ["java", "-jar", "/app/tla-web-backend.jar"]
+ENTRYPOINT ["sh", "/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -26,15 +26,16 @@ Requirements:
 #### Prerequesites
 
 1. Create an environment variable template file `.env` based on the template coming with this repo:
-
-    cp .env.template .env
-
+   ```
+   cp .env.template .env
+   ```
 2. Choose values for the environment variables `ES_HOST` and `ES_PORT` to your liking, e.g. as `localhost` and `9200`
    respectively (or wherever you desire to be able to connect to your Elasticsearch container).
 
 3. Specify the location where a TLA corpus data archive can be downloaded using the `SAMPLE_URL` environment variable, e.g.:
-
-    SAMPLE_URL=http://example.org/sample.tar.gz
+   ```
+   SAMPLE_URL=http://example.org/sample.tar.gz
+   ```
 
 #### Run Setup
 
@@ -64,13 +65,13 @@ Requirements:
 #### Prerequesites
 
 1. This method requires you to provide a running Elasticsearch instance. If you have Docker Compose, you can simply start one in a
-container by using the configuration coming with this repository:
-
-    docker-compose up -d es
-
-Before continuing, make sure Elasticsearch is running by checking the output of `docker ps --all` or
-accessing [its REST interface](http://localhost:9200) in a browser (change `9200` in case that you
-set a different port via the `ES_PORT` environment variable).
+   container by using the configuration coming with this repository:
+   ```
+   docker-compose up -d es
+   ```
+   Before continuing, make sure Elasticsearch is running by checking the output of `docker ps --all` or
+   accessing [its REST interface](http://localhost:9200) in a browser (change `9200` in case that you
+   set a different port via the `ES_PORT` environment variable).
 
 2. Nicely done! Now follow the instructions above to make sure you have set the environment variables `ES_HOST`, `ES_PORT` and `SAMPLE_URL`.
 
@@ -78,15 +79,15 @@ set a different port via the `ES_PORT` environment variable).
 you must set the `SAMPLE_URL` environment variable to a URL pointing to a tar-compressed TLA corpus data
 file. One way to do this is to create a `.env` file in the directory containing this README, and setting
 the variable `SAMPLE_URL` in there:
+   ```
+   SAMPLE_URL=http://example.org/sample.tar.gz
+   ```
 
-    SAMPLE_URL=http://example.org/sample.tar.gz
-
-Finally, download and store TLA corpus data from the specified source by running the `populate` gradle task:
-
-    gradle populate
-
-(If you are on a Windows machine, you probably need to execute the `gradlew.bat` wrapper shipped with this
-project explicitly.)
+4. Finally, download and store TLA corpus data from the specified source by running the `populate` gradle task:
+   ```
+   ./gradlew populate
+   ```
+> If you are on a Windows machine, you have to use the `gradlew.bat` wrapper instead.)
 
 #### Run application
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The TLA backend server is a Spring Boot application using an Elasticsearch insta
 
 ## Installation
 
+> **TL;DR:** run `ES_PORT=9200 SAMPLE_URL=http://aaew64.bbaw.de/resources/sample/sample200526-5000t.tar.gz docker-compose up -d --build --force-recreate`
+
 There are two methods for getting this thing up and running.
 
 1. [As a Docker container setup](#1-using-docker)

--- a/README.md
+++ b/README.md
@@ -4,26 +4,77 @@
 
 Thesaurus Linguae Aegyptiae (TLA) backend.
 
+## Overview
+
+The TLA backend server is a Spring Boot application using an Elasticsearch instance as a search engine.
+
+
 ## Installation
+
+There are two methods for getting this thing up and running.
+
+1. As a Docker container setup
+2. Run or build with Gradle
+
+
+### 1. Using Docker
+
+Requirements:
+
+- Docker Compose
+
+#### Prerequesites
+
+1. Create an environment variable template file `.env` based on the template coming with this repo:
+
+    cp .env.template .env
+
+2. Choose values for the environment variables `ES_HOST` and `ES_PORT` to your liking, e.g. as `localhost` and `9200`
+   respectively (or wherever you desire to be able to connect to your Elasticsearch container).
+
+3. Specify the location where a TLA corpus data archive can be downloaded using the `SAMPLE_URL` environment variable, e.g.:
+
+    SAMPLE_URL=http://example.org/sample.tar.gz
+
+#### Run Setup
+
+Start the docker container setup configured in `docker-compose.yml`:
+
+    docker-compose up -d
+
+This will build and run three containers:
+
+- `tla-es`: Elasticsearch container
+- `tla-ingest`: temporarily executed instance of the backend application, used for populating the Elasticsearch container
+- `tla-backend`: the actual backend app
+
+The `tla-ingest` container will take its time downloading the TLA corpus data archive file and uploading it into Elasticsearch.
+You can check its progress by taking a look into its log output:
+
+    docker logs -f tla-ingest
+
+
+### 2. Using Gradle
 
 Requirements:
 
 - Java 11
-- Docker Compose
+- Elasticsearch 7.6.2 or Docker Compose
 
+#### Prerequesites
 
-### 1. Install and populate search engine
+1. This method requires you to provide a running Elasticsearch instance. If you have Docker Compose, you can simply start one in a
+container by using the configuration coming with this repository:
 
-The TLA backend app requires Elasticsearch 7.6.2. It can be installed via Docker Compose using the
-configuration shipped with this repository:
-
-    docker-compose up -d elasticsearch
+    docker-compose up -d es
 
 Before continuing, make sure Elasticsearch is running by checking the output of `docker ps --all` or
 accessing [its REST interface](http://localhost:9200) in a browser (change `9200` in case that you
 set a different port via the `ES_PORT` environment variable).
 
-Once Elasticsearch is up and running, TLA corpus data needs to be loaded into it. In order to do so,
+2. Nicely done! Now follow the instructions above to make sure you have set the environment variables `ES_HOST`, `ES_PORT` and `SAMPLE_URL`.
+
+3. Once Elasticsearch is up and running, TLA corpus data needs to be loaded into it. In order to do so,
 you must set the `SAMPLE_URL` environment variable to a URL pointing to a tar-compressed TLA corpus data
 file. One way to do this is to create a `.env` file in the directory containing this README, and setting
 the variable `SAMPLE_URL` in there:
@@ -32,36 +83,21 @@ the variable `SAMPLE_URL` in there:
 
 Finally, download and store TLA corpus data from the specified source by running the `populate` gradle task:
 
-
     gradle populate
 
 (If you are on a Windows machine, you probably need to execute the `gradlew.bat` wrapper shipped with this
 project explicitly.)
 
+#### Run application
 
-### 2. Run the app
+Run the app using the `bootRun` task:
 
-Run the app via the `bootRun` task:
+    ./gradlew bootrun
 
-    gradle bootrun
-
-(If you are on a Windows machine, you probably need to execute the `gradlew.bat` wrapper shipped with this
-project explicitly.)
+> If you are on a Windows machine, you need to execute the `gradlew.bat` wrapper shipped with this repository.
 
 
 ## Misc
-
-Run a dockerized setup using Docker Compose:
-
-    docker-compose up -d elasticsearch
-    ./gradlew downloadSample
-    docker-compose up -d backend
-
-
-In order to only use the Elasticsearch container and run the application via gradle:
-
-    docker-compose up -d elasticsearch
-    ./gradlew populate bootRun
 
 *Note:* You can configure the Elasticsearch HTTP port to which the application will try to connect.
 Both the Docker Compose configuration and the `bootRun` and `test` gradle tasks are going to read
@@ -73,7 +109,6 @@ When running the application using the  `bootRun` task, comma-separated argument
     ./gradlew bootRun --Pargs=--data-file=sample.tar.gz,--foo=bar
     ./gradlew bootRun --args="--data-file=sample.tar.gz --foo=bar"
 
-
 Populate database with a corpus dump and shut down after:
 
     ./gradlew bootRun --args="--date-file=sample.tar.gz --shutdown"
@@ -83,9 +118,7 @@ from a URL specified via the `SAMPLE_URL` environment variable:
 
     ./gradlew populate
 
-
 You can check for the newest version of package dependencies by running:
 
     ./gradlew dependencyUpdates
-
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The TLA backend server is a Spring Boot application using an Elasticsearch insta
 
 There are two methods for getting this thing up and running.
 
-1. As a Docker container setup
-2. Run or build with Gradle
+1. [As a Docker container setup](#1-using-docker)
+2. [Run or build with Gradle](#2-using-gradle)
 
 
 ### 1. Using Docker
@@ -23,7 +23,7 @@ Requirements:
 
 - Docker Compose
 
-#### Prerequesites
+#### 1.1. Prerequesites
 
 1. Create an environment variable template file `.env` based on the template coming with this repo:
    ```
@@ -37,7 +37,7 @@ Requirements:
    SAMPLE_URL=http://example.org/sample.tar.gz
    ```
 
-#### Run Setup
+#### 1.2. Run Setup
 
 Start the docker container setup configured in `docker-compose.yml`:
 
@@ -60,9 +60,9 @@ You can check its progress by taking a look into its log output:
 Requirements:
 
 - Java 11
-- Elasticsearch 7.6.2 or Docker Compose
+- Elasticsearch 7.6.2 *or* Docker Compose
 
-#### Prerequesites
+#### 2.1. Prerequesites
 
 1. This method requires you to provide a running Elasticsearch instance. If you have Docker Compose, you can simply start one in a
    container by using the configuration coming with this repository:
@@ -89,7 +89,7 @@ the variable `SAMPLE_URL` in there:
    ```
 > If you are on a Windows machine, you have to use the `gradlew.bat` wrapper instead.)
 
-#### Run application
+#### 2.2. Run application
 
 Run the app using the `bootRun` task:
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Requirements:
    accessing [its REST interface](http://localhost:9200) in a browser (change `9200` in case that you
    set a different port via the `ES_PORT` environment variable).
 
-2. Nicely done! Now follow the instructions above to make sure you have set the environment variables `ES_HOST`, `ES_PORT` and `SAMPLE_URL`.
+2. Nicely done! Now follow [the instructions above](#11-prerequesites) to make sure you have set the environment variables `ES_HOST`, `ES_PORT` and `SAMPLE_URL`.
 
 3. Once Elasticsearch is up and running, TLA corpus data needs to be loaded into it. In order to do so,
 you must set the `SAMPLE_URL` environment variable to a URL pointing to a tar-compressed TLA corpus data

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The TLA backend server is a Spring Boot application using an Elasticsearch insta
 
 ## Installation
 
-> **TL;DR:** run `ES_PORT=9200 SAMPLE_URL=http://aaew64.bbaw.de/resources/sample/sample200526-5000t.tar.gz docker-compose up -d --build --force-recreate`
+> **TL;DR:** run `ES_PORT=9200 SAMPLE_URL=http://aaew64.bbaw.de/resources/sample/sample200526-5000t.tar.gz docker-compose up -d`
 
 There are two methods for getting this thing up and running.
 

--- a/bin/run/entrypoint.sh
+++ b/bin/run/entrypoint.sh
@@ -6,7 +6,11 @@ CMD=runserver
 if [ $# -ge 1 ]; then
     if [[ "$1" = "ingest" ]]; then
         echo "download corpus data from ${SAMPLE_URL}..."
-        wget "${SAMPLE_URL}" -O sample.tar.gz || $(echo "could not retrieve corpus data!"; exit 1)
+        wget "${SAMPLE_URL}" -O sample.tar.gz
+        if [ ! $? -eq 0 ]; then
+            echo "could not retrieve corpus data!"
+            exit 1
+        fi
         CMD=populate
     fi
 fi

--- a/bin/run/entrypoint.sh
+++ b/bin/run/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+ES_HOST="${ES_HOST:-localhost}"
 ES_URL="${ES_HOST}:${ES_PORT}"
 CMD=runserver
 

--- a/bin/run/entrypoint.sh
+++ b/bin/run/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+ES_URL="${ES_HOST}:${ES_PORT}"
+CMD=runserver
+
+if [ $# -ge 1 ]; then
+    if [[ "$1" = "ingest" ]]; then
+        echo "download corpus data from ${SAMPLE_URL}..."
+        wget "${SAMPLE_URL}" -O sample.tar.gz || $(echo "could not retrieve corpus data!"; exit 1)
+        CMD=populate
+    fi
+fi
+
+while true; do
+        resp=$(wget -q --spider "${ES_URL}" 2>/dev/null)
+        [ $? -eq 0 ] && break
+        echo "waiting for connection to ES instance at ${ES_URL}..."
+        sleep 4
+done
+
+if [[ "${CMD}" = "populate" ]]; then
+    echo "populate database..."
+    java -jar tla-backend.jar --data-file=sample.tar.gz --shutdown
+else
+    echo "run backend server..."
+    java -jar tla-backend.jar
+fi

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ application {
 
 test {
     useJUnitPlatform()
-    environment "ES_PORT", env.ES_PORT.orElse("9200")
+    environment "ES_PORT", env.fetch("ES_PORT", "9200")
     finalizedBy 'jacocoTestReport'
 }
 
@@ -92,14 +92,14 @@ bootRun {
     if (project.hasProperty('args')) {
         args project.args.split(',')
     }
-    environment "ES_PORT", env.ES_PORT.orElse("9200")
-    environment "ES_HOST", env.ES_HOST.orElse("localhost")
+    environment "ES_PORT", env.fetch("ES_PORT", "9200")
+    environment "ES_HOST", env.fetch("ES_HOST", "localhost")
 }
 
 task downloadSample(type: Download) {
     group = 'Init'
     description = 'Download corpus sample file'
-    src env.SAMPLE_URL.orElse("http://")
+    src env.fetch("SAMPLE_URL", "http://")
     dest new File('sample.tar.gz')
     onlyIfModified true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'org.bbaw.aaew.tla'
-version = '0.0.7-SNAPSHOT'
+version = '0.0.8-SNAPSHOT'
 sourceCompatibility = '11'
 
 publishing {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ version: '3.7'
 
 services:
 
-    elasticsearch:
+    es:
+        container_name: tla-es
         image: docker.elastic.co/elasticsearch/elasticsearch:7.6.2
         environment:
             ES_JAVA_OPTS: -Xms512m -Xmx512m
@@ -12,21 +13,34 @@ services:
             - ${ES_PORT}:9200
         stdin_open: true
         tty: true
+        restart: unless-stopped
 
-    backend:
+    populate:
+        container_name: tla-ingest
         depends_on:
-            - elasticsearch
+            - es
         build:
             context: .
-            args:
-                - es_port=${ES_PORT}
-                - es_host=localhost
+        environment:
+            ES_HOST: es
+            ES_PORT: ${ES_PORT}
+            SAMPLE_URL: ${SAMPLE_URL}
+        tty: true
+        command: "ingest"
+
+    backend:
+        container_name: tla-backend
+        depends_on:
+            - populate
+        build:
+            context: .
+        environment:
+            ES_HOST: ${ES_HOST}
+            ES_PORT: ${ES_PORT}
         ports:
             - 8090:8090
         tty: true
         network_mode: host
-        volumes:
-            - ${PWD}/sample.tar.gz:/app/sample.tar.gz
-        command: "--data-file=sample.tar.gz"
+        restart: unless-stopped
 
-
+...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
             context: .
         environment:
             ES_HOST: es
-            ES_PORT: ${ES_PORT}
+            ES_PORT: 9200
             SAMPLE_URL: ${SAMPLE_URL}
         tty: true
         command: "ingest"


### PR DESCRIPTION
Introducing an `entrypoint.sh` script waiting for ES connection, handling download of corpus data and execution of `jar`-file, therefore enabling re-use docker image in docker compose configuration, so that everything can now happen inside containers and setting up an ES instance, downloading and ingesting corpus data, and running the backend server is now as easy as:

    docker-compose up -d