### PR TITLE
Include related objects in search results container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:6.7.1-jdk11 AS build
+FROM gradle:6.8.1-jdk11 AS build
 
 COPY --chown=gradle:gradle . /home/gradle/tla
 WORKDIR /home/gradle/tla

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![build](https://github.com/jkatzwinkel/tla-es/workflows/build/badge.svg)
 ![deploy](https://github.com/jkatzwinkel/tla-es/workflows/deploy/badge.svg)
-![LINE](https://img.shields.io/badge/line--coverage-61%25-yellow.svg)
-![METHOD](https://img.shields.io/badge/method--coverage-71%25-yellow.svg)
+![LINE](https://img.shields.io/badge/line--coverage-68%25-yellow.svg)
+![METHOD](https://img.shields.io/badge/method--coverage-76%25-yellow.svg)
 
 # tla-es
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-![build](https://github.com/thesaurus-linguae-aegyptiae/tla-es/workflows/build/badge.svg)
-![deploy](https://github.com/thesaurus-linguae-aegyptiae/tla-es/workflows/deploy/badge.svg)
-![LINE](https://img.shields.io/badge/line--coverage-57%25-orange.svg)
-![METHOD](https://img.shields.io/badge/method--coverage-69%25-yellow.svg)
+![build](https://github.com/jkatzwinkel/tla-es/workflows/build/badge.svg)
+![deploy](https://github.com/jkatzwinkel/tla-es/workflows/deploy/badge.svg)
+![LINE](https://img.shields.io/badge/line--coverage-61%25-yellow.svg)
+![METHOD](https://img.shields.io/badge/method--coverage-71%25-yellow.svg)
 
 # tla-es
 
@@ -17,7 +17,7 @@ The TLA backend server is a Spring Boot application using Elasticsearch as a sea
 
 ## Installation
 
-> **TL;DR:** run `SAMPLE_URL=http://aaew64.bbaw.de/resources/tla-data/tla-sample-20210113-1000t.tar.gz docker-compose up -d`
+> **TL;DR:** run `SAMPLE_URL=http://aaew64.bbaw.de/resources/tla-data/tla-sample-20210115-1000t.tar.gz docker-compose up -d`
 
 There are two methods for getting this thing up and running.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![build](https://github.com/JKatzwinkel/tla-es/workflows/build/badge.svg)
-![LINE](https://img.shields.io/badge/line--coverage-57%25-orange.svg)
+![LINE](https://img.shields.io/badge/line--coverage-58%25-orange.svg)
 ![METHOD](https://img.shields.io/badge/method--coverage-69%25-yellow.svg)
 
 Thesaurus Linguae Aegyptiae (TLA) backend.

--- a/build.gradle
+++ b/build.gradle
@@ -6,13 +6,13 @@ plugins {
     id 'maven-publish'
     id 'co.uzzu.dotenv.gradle' version '1.1.0'
     id 'de.undercouch.download' version '4.1.1'
-    id 'org.springframework.boot' version '2.4.1'
+    id 'org.springframework.boot' version '2.4.2'
     id 'com.github.ben-manes.versions' version '0.36.0'
     id 'com.github.dawnwords.jacoco.badge' version '0.2.0'
 }
 
 group = 'org.bbaw.aaew.tla'
-version = '0.0.827-SNAPSHOT'
+version = '0.0.830'
 sourceCompatibility = '11'
 
 publishing {
@@ -49,8 +49,8 @@ configurations {
 }
 
 dependencies {
-    compileOnly 'org.projectlombok:lombok:1.18.16'
-    annotationProcessor 'org.projectlombok:lombok:1.18.16'
+    compileOnly 'org.projectlombok:lombok:1.18.18'
+    annotationProcessor 'org.projectlombok:lombok:1.18.18'
 
     implementation 'com.github.thesaurus-linguae-aegyptiae:tla-common:master-SNAPSHOT'
     implementation 'org.modelmapper:modelmapper:2.3.9'
@@ -59,13 +59,13 @@ dependencies {
     implementation 'org.yaml:snakeyaml:1.27'
 
     implementation 'org.springframework.data:spring-data-elasticsearch:4.2.0-M1'
-    implementation 'org.springframework.boot:spring-boot:2.4.1'
-    implementation 'org.springframework.boot:spring-boot-autoconfigure:2.4.1'
+    implementation 'org.springframework.boot:spring-boot:2.5.0-M1'
+    implementation 'org.springframework.boot:spring-boot-autoconfigure:2.5.0-M1'
     implementation 'org.springframework:spring-web:5.3.3'
     implementation 'org.springframework:spring-webmvc:5.3.3'
     implementation 'org.slf4j:slf4j-simple:2.0.0-alpha1'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.4.1'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.5.0-M1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.18'
     annotationProcessor 'org.projectlombok:lombok:1.18.18'
 
-    implementation 'com.github.thesaurus-linguae-aegyptiae:tla-common:master-SNAPSHOT'
+    implementation 'com.github.jkatzwinkel:tla-common:query-expansion-SNAPSHOT'
     implementation 'org.modelmapper:modelmapper:2.3.9'
     implementation 'org.apache.commons:commons-compress:1.20'
     implementation 'org.apache.tomcat.embed:tomcat-embed-core:9.0.35'

--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,10 @@ jacocoTestReport {
     finalizedBy 'generateJacocoBadge'
 }
 
+springBoot {
+    buildInfo()
+}
+
 bootRun {
     if (project.hasProperty('args')) {
         args project.args.split(',')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/tla/backend/api/ApiController.java
+++ b/src/main/java/tla/backend/api/ApiController.java
@@ -1,8 +1,10 @@
 package tla.backend.api;
 
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +19,9 @@ public class ApiController {
     @Autowired
     private RequestMappingHandlerMapping handlerMapping;
 
+    @Autowired
+    private BuildProperties buildProperties;
+
     /**
      * list all registered endpoints
      */
@@ -30,6 +35,19 @@ public class ApiController {
                 ).sorted().collect(
                     Collectors.toList()
                 )
+            ),
+            HttpStatus.OK
+        );
+    }
+
+    /**
+     * Returns version info.
+     */
+    @RequestMapping(value = "/version", method = RequestMethod.GET)
+    public ResponseEntity<?> getVersionInfo() {
+        return new ResponseEntity<>(
+            Map.of(
+                "version", buildProperties.getVersion()
             ),
             HttpStatus.OK
         );

--- a/src/main/java/tla/backend/api/ApiController.java
+++ b/src/main/java/tla/backend/api/ApiController.java
@@ -12,6 +12,9 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
+import tla.backend.es.model.Metadata;
+import tla.backend.service.MetadataService;
+
 @RestController
 @RequestMapping("/")
 public class ApiController {
@@ -21,6 +24,9 @@ public class ApiController {
 
     @Autowired
     private BuildProperties buildProperties;
+
+    @Autowired
+    private MetadataService metadataService;
 
     /**
      * list all registered endpoints
@@ -45,9 +51,16 @@ public class ApiController {
      */
     @RequestMapping(value = "/version", method = RequestMethod.GET)
     public ResponseEntity<?> getVersionInfo() {
+        Metadata info = this.metadataService.getInfo();
         return new ResponseEntity<>(
             Map.of(
-                "version", buildProperties.getVersion()
+                "version", buildProperties.getVersion(),
+                "DOI", info.getDOI(),
+                "date", info.getDate(),
+                "release", info.getId(),
+                "modelVersion", info.getModelVersion(),
+                "etlVersion", info.getEtlVersion(),
+                "lingglossVersion", info.getLingglossVersion()
             ),
             HttpStatus.OK
         );

--- a/src/main/java/tla/backend/es/model/Metadata.java
+++ b/src/main/java/tla/backend/es/model/Metadata.java
@@ -1,0 +1,54 @@
+package tla.backend.es.model;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import tla.backend.es.model.meta.Indexable;
+import tla.backend.es.model.parts.EditDate;
+import tla.domain.model.meta.AbstractBTSBaseClass;
+import tla.domain.model.meta.BTSeClass;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@BTSeClass("TLAMetadata")
+@Document(indexName = "meta")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Metadata extends AbstractBTSBaseClass implements Indexable {
+
+    @Id
+    @Field(type = FieldType.Keyword)
+    @JsonAlias({"version"})
+    private String id;
+
+    @Field(type = FieldType.Keyword)
+    @JsonAlias({"DOI"})
+    private String DOI;
+
+    @Field(type = FieldType.Date, format = DateFormat.custom, pattern = "yyyy-MM-dd")
+    @JsonFormat(pattern = "yyyy-MM-dd", timezone = "UTC")
+    private EditDate date;
+
+    @Field(type = FieldType.Keyword)
+    @JsonAlias({"etl-version"})
+    private String etlVersion;
+
+    @Field(type = FieldType.Keyword)
+    @JsonAlias({"model-version"})
+    private String modelVersion;
+
+    @Field(type = FieldType.Keyword)
+    @JsonAlias({"linggloss-version"})
+    private String lingglossVersion;
+
+}

--- a/src/main/java/tla/backend/es/model/meta/ModelConfig.java
+++ b/src/main/java/tla/backend/es/model/meta/ModelConfig.java
@@ -93,7 +93,7 @@ public class ModelConfig {
         DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
 
-    private static ModelMapper modelMapper;
+    protected static ModelMapper modelMapper;
 
     @Getter
     private static List<Class<? extends AbstractBTSBaseClass>> modelClasses = new LinkedList<>();
@@ -222,7 +222,7 @@ public class ModelConfig {
         return modelMapper;
     }
 
-    private static ModelMapper initModelMapper() {
+    protected static ModelMapper initModelMapper() {
         log.debug("initializing model mapper");
         modelMapper = new ModelMapper();
         Translations.ToMapConverter translationsToMapConverter = new Translations.ToMapConverter();

--- a/src/main/java/tla/backend/es/model/meta/ModelConfig.java
+++ b/src/main/java/tla/backend/es/model/meta/ModelConfig.java
@@ -301,7 +301,11 @@ public class ModelConfig {
                 SentenceSearch::getTranslation, SentenceSearchQueryBuilder::setTranslation
             )
         );
-        modelMapper.createTypeMap(SentenceSearch.TokenSpec.class, TokenSearchQueryBuilder.class);
+        modelMapper.createTypeMap(SentenceSearch.TokenSpec.class, TokenSearchQueryBuilder.class).addMappings(
+            m -> m.using(new TranslationSpecConverter()).map(
+                SentenceSearch.TokenSpec::getTranslation, TokenSearchQueryBuilder::setTranslation
+            )
+        );
         return modelMapper;
     }
 

--- a/src/main/java/tla/backend/es/model/parts/Token.java
+++ b/src/main/java/tla/backend/es/model/parts/Token.java
@@ -10,14 +10,14 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
-@EqualsAndHashCode
+@ToString
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -61,8 +61,8 @@ public class Token {
 
     @Getter
     @Setter
+    @ToString
     @NoArgsConstructor
-    @EqualsAndHashCode
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Flexion {
@@ -90,7 +90,7 @@ public class Token {
 
     @Getter
     @Setter
-    @EqualsAndHashCode
+    @ToString
     @NoArgsConstructor
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class Lemmatization {
@@ -109,7 +109,7 @@ public class Token {
 
     @Getter
     @Setter
-    @EqualsAndHashCode
+    @ToString
     @NoArgsConstructor
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/tla/backend/es/query/ESQueryResult.java
+++ b/src/main/java/tla/backend/es/query/ESQueryResult.java
@@ -13,6 +13,9 @@ import lombok.Setter;
 import tla.backend.es.model.meta.Indexable;
 import tla.domain.dto.extern.PageInfo;
 
+/**
+ * ES search hits container with paging information.
+ */
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/tla/backend/es/query/ESQueryResult.java
+++ b/src/main/java/tla/backend/es/query/ESQueryResult.java
@@ -15,6 +15,8 @@ import tla.domain.dto.extern.PageInfo;
 
 /**
  * ES search hits container with paging information.
+ *
+ * <code>&lt;T&gt;</code>: an {@link Indexable} entity class
  */
 @Getter
 @Setter

--- a/src/main/java/tla/backend/es/query/MultiLingQueryBuilder.java
+++ b/src/main/java/tla/backend/es/query/MultiLingQueryBuilder.java
@@ -17,16 +17,16 @@ public interface MultiLingQueryBuilder extends TLAQueryBuilder {
                 translationsQuery.should(
                     termSpecified
                     ? matchQuery(
-                        String.format("translations.%s", lang),
+                        String.format("%stranslations.%s", this.nestedPath(), lang),
                         translation.getText()
                     )
                     : existsQuery(
-                        String.format("translations.%s", lang)
+                        String.format("%stranslations.%s", this.nestedPath(), lang)
                     )
                 );
             }
         }
-        this.must(translationsQuery);
+        this.should(translationsQuery);
     }
 
 }

--- a/src/main/java/tla/backend/es/query/SentenceSearchQueryBuilder.java
+++ b/src/main/java/tla/backend/es/query/SentenceSearchQueryBuilder.java
@@ -17,15 +17,17 @@ import tla.domain.command.PassportSpec;
 public class SentenceSearchQueryBuilder extends ESQueryBuilder implements MultiLingQueryBuilder {
 
     public void setTokens(Collection<TokenSearchQueryBuilder> tokenQueries) {
-        tokenQueries.forEach(
-            query -> this.filter(
-                QueryBuilders.nestedQuery(
-                    "tokens",
-                    query.getNativeRootQueryBuilder(),
-                    ScoreMode.None
+        if (tokenQueries != null) {
+            tokenQueries.forEach(
+                query -> this.filter(
+                    QueryBuilders.nestedQuery(
+                        "tokens",
+                        query.getNativeRootQueryBuilder(),
+                        ScoreMode.None
+                    )
                 )
-            )
-        );
+            );
+        }
     }
 
     public void setPassport(PassportSpec spec) {

--- a/src/main/java/tla/backend/es/query/TLAQueryBuilder.java
+++ b/src/main/java/tla/backend/es/query/TLAQueryBuilder.java
@@ -92,26 +92,39 @@ public interface TLAQueryBuilder {
         return deps;
     }
 
+    /**
+     * ES root query builder which queries for individual properties get added to
+     * either as <code>must</code> or <code>should</code> clause, or as a <code>filter</code>.
+     */
     public BoolQueryBuilder getNativeRootQueryBuilder();
+
+    /**
+     * Create JSON string representation of native ES query.
+     */
+    public default String toJson() {
+        return this.getNativeRootQueryBuilder().toString();
+    }
 
     public List<AbstractAggregationBuilder<?>> getNativeAggregationBuilders();
 
+    /**
+     * returns ES search hits and page information wrapped together into one object.
+     */
     public ESQueryResult<?> getResult();
     public void setResult(ESQueryResult<?> result);
 
     /**
-     * Conjunct criterion with bool query's <code>must</code> clause list.
+     * Add criterion to root query's <code>must</code> clause list.
      */
     default BoolQueryBuilder must(QueryBuilder clause) {
         return this.getNativeRootQueryBuilder().must(clause);
     }
     /**
-     * Disjunct criterion with bool query's <code>should</code> clause list.
+     * Add criterion to root query's <code>should</code> clause list.
      */
     default BoolQueryBuilder should(QueryBuilder clause) {
         return this.getNativeRootQueryBuilder().should(clause);
     }
-
     /**
      * add filter
      */
@@ -132,6 +145,14 @@ public interface TLAQueryBuilder {
             return ((ModelClass) a).value();
         }
         return null;
+    }
+
+    /**
+     * queries for elements with a nested mapping should override this and
+     * return the actual path where they are nested (ending with the <code>"."</code> path delimiter).
+     */
+    default String nestedPath() {
+        return "";
     }
 
 }

--- a/src/main/java/tla/backend/es/query/TokenSearchQueryBuilder.java
+++ b/src/main/java/tla/backend/es/query/TokenSearchQueryBuilder.java
@@ -4,12 +4,20 @@ import org.elasticsearch.index.query.QueryBuilders;
 
 import tla.domain.model.SentenceToken.Lemmatization;
 
-public class TokenSearchQueryBuilder extends ESQueryBuilder {
+public class TokenSearchQueryBuilder extends ESQueryBuilder implements MultiLingQueryBuilder {
+
+    @Override
+    public String nestedPath() {
+        return "tokens.";
+    }
 
     public void setLemma(Lemmatization lemma) {
         if (lemma != null && !lemma.isEmpty()) {
             this.must(
-                QueryBuilders.termQuery("tokens.lemma.id", lemma.getId())
+                QueryBuilders.termQuery(
+                    String.format("%slemma.id", this.nestedPath()),
+                    lemma.getId()
+                )
             );
         }
     }

--- a/src/main/java/tla/backend/es/repo/MetadataRepo.java
+++ b/src/main/java/tla/backend/es/repo/MetadataRepo.java
@@ -1,0 +1,7 @@
+package tla.backend.es.repo;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import tla.backend.es.model.Metadata;
+
+public interface MetadataRepo extends ElasticsearchRepository<Metadata, String> {}

--- a/src/main/java/tla/backend/service/AnnotationService.java
+++ b/src/main/java/tla/backend/service/AnnotationService.java
@@ -23,7 +23,8 @@ public class AnnotationService extends EntityService<AnnotationEntity, Elasticse
     }
 
     @Override
-    public ESQueryBuilder getSearchCommandAdapter(SearchCommand<AnnotationDto> command) {
+    public Class<? extends ESQueryBuilder> getSearchCommandAdapterClass(SearchCommand<AnnotationDto> command) {
+        // TODO
         return null;
     }
 

--- a/src/main/java/tla/backend/service/CommentService.java
+++ b/src/main/java/tla/backend/service/CommentService.java
@@ -23,9 +23,8 @@ public class CommentService extends EntityService<CommentEntity, ElasticsearchRe
     }
 
     @Override
-    public ESQueryBuilder getSearchCommandAdapter(SearchCommand<CommentDto> command) {
-        // TODO Auto-generated method stub
+    public Class<? extends ESQueryBuilder> getSearchCommandAdapterClass(SearchCommand<CommentDto> command) {
+        // TODO
         return null;
     }
-    
 }

--- a/src/main/java/tla/backend/service/CorpusObjectService.java
+++ b/src/main/java/tla/backend/service/CorpusObjectService.java
@@ -25,8 +25,8 @@ public class CorpusObjectService extends
     }
 
     @Override
-    public ESQueryBuilder getSearchCommandAdapter(SearchCommand<CorpusObjectDto> command) {
-        return this.getModelMapper().map(command, TextSearchQueryBuilder.class);
+    public Class<? extends ESQueryBuilder> getSearchCommandAdapterClass(SearchCommand<CorpusObjectDto> command) {
+        return TextSearchQueryBuilder.class;
     }
 
 }

--- a/src/main/java/tla/backend/service/EntityService.java
+++ b/src/main/java/tla/backend/service/EntityService.java
@@ -227,7 +227,7 @@ public abstract class EntityService<T extends Indexable, R extends Elasticsearch
     }
 
     /**
-     * If a document if an instance of {@link LinkedEntity}, go through its
+     * If a document is an instance of {@link LinkedEntity}, go through its
      * {@link LinkedEntity#getRelations()} data structure and
      * try to look up all objects referenced in their respective Elasticsearch indices based on
      * their <code>eclass</code> value.
@@ -401,7 +401,7 @@ public abstract class EntityService<T extends Indexable, R extends Elasticsearch
     public Optional<SearchResultsWrapper<? extends D>> runSearchCommand(SearchCommand<D> command, Pageable page) {
         log.info("page: {}", page);
         var queryAdapter = this.getSearchCommandAdapter(command);
-        var result = searchService.register(queryAdapter).run(page);
+        ESQueryResult<?> result = searchService.register(queryAdapter).run(page);
         try {
             var wrapper = new SearchResultsWrapper<D>(
                 hitsToDTO(result.getHits(), this.getDtoClass()),

--- a/src/main/java/tla/backend/service/LemmaService.java
+++ b/src/main/java/tla/backend/service/LemmaService.java
@@ -154,10 +154,8 @@ public class LemmaService extends EntityService<LemmaEntity, ElasticsearchReposi
     }
 
     @Override
-    public ESQueryBuilder getSearchCommandAdapter(SearchCommand<LemmaDto> command) {
-        return this.getModelMapper().map(
-            command, LemmaSearchQueryBuilder.class
-        );
+    public Class<? extends ESQueryBuilder> getSearchCommandAdapterClass(SearchCommand<LemmaDto> command) {
+        return LemmaSearchQueryBuilder.class;
     }
 
 }

--- a/src/main/java/tla/backend/service/LemmaService.java
+++ b/src/main/java/tla/backend/service/LemmaService.java
@@ -128,7 +128,7 @@ public class LemmaService extends EntityService<LemmaEntity, ElasticsearchReposi
     }
 
     public Map<String, Long> getMostFrequent(int limit) {
-        SearchResponse response = query(SentenceEntity.class, matchAllQuery(),
+        SearchResponse response = this.searchService.query(SentenceEntity.class, matchAllQuery(),
                 AggregationBuilders.nested("aggs", "tokens").subAggregation(AggregationBuilders.terms("lemmata")
                         .field("tokens.lemma.id").order(BucketOrder.count(false)).size(limit)));
         Nested aggs = response.getAggregations().get("aggs");

--- a/src/main/java/tla/backend/service/MetadataService.java
+++ b/src/main/java/tla/backend/service/MetadataService.java
@@ -1,0 +1,42 @@
+package tla.backend.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Service;
+
+import tla.backend.es.model.Metadata;
+import tla.backend.es.query.ESQueryBuilder;
+import tla.backend.es.repo.MetadataRepo;
+import tla.domain.command.SearchCommand;
+import tla.domain.dto.meta.DocumentDto;
+
+@Service
+@ModelClass(value = Metadata.class, path = "meta")
+public class MetadataService extends EntityService<Metadata, ElasticsearchRepository<Metadata, String>, DocumentDto> {
+
+    @Autowired
+    private MetadataRepo repo;
+
+    private Metadata metadata;
+
+    public Metadata getInfo() {
+        if (metadata == null) {
+            this.repo.findAll().forEach(
+                m -> {
+                    metadata = m;
+                }
+            );
+        }
+        return metadata;
+    }
+
+    @Override
+    public ElasticsearchRepository<Metadata, String> getRepo() {
+        return repo;
+    }
+
+    @Override
+    public Class<? extends ESQueryBuilder> getSearchCommandAdapterClass(SearchCommand<DocumentDto> command) {
+        return null;
+    }
+}

--- a/src/main/java/tla/backend/service/SentenceService.java
+++ b/src/main/java/tla/backend/service/SentenceService.java
@@ -56,7 +56,7 @@ public class SentenceService extends EntityService<SentenceEntity, Elasticsearch
      * Count occurrences of the specified lemma in each text.
      */
     public Map<String, Long> lemmaFrequencyPerText(String lemmaId) {
-        SearchResponse response = query(
+        SearchResponse response = this.searchService.query(
             SentenceEntity.class,
             nestedQuery(
                 "tokens",

--- a/src/main/java/tla/backend/service/SentenceService.java
+++ b/src/main/java/tla/backend/service/SentenceService.java
@@ -80,8 +80,8 @@ public class SentenceService extends EntityService<SentenceEntity, Elasticsearch
     }
 
     @Override
-    public ESQueryBuilder getSearchCommandAdapter(SearchCommand<SentenceDto> command) {
-        return this.getModelMapper().map(command, SentenceSearchQueryBuilder.class);
+    public Class<? extends ESQueryBuilder> getSearchCommandAdapterClass(SearchCommand<SentenceDto> command) {
+        return SentenceSearchQueryBuilder.class;
     }
 
 }

--- a/src/main/java/tla/backend/service/TextService.java
+++ b/src/main/java/tla/backend/service/TextService.java
@@ -53,8 +53,8 @@ public class TextService extends UserFriendlyEntityService<TextEntity, UserFrien
     }
 
     @Override
-    public ESQueryBuilder getSearchCommandAdapter(SearchCommand<TextDto> command) {
-        return this.getModelMapper().map(command, TextSearchQueryBuilder.class);
+    public Class<? extends ESQueryBuilder> getSearchCommandAdapterClass(SearchCommand<TextDto> command) {
+        return TextSearchQueryBuilder.class;
     }
 
 }

--- a/src/main/java/tla/backend/service/ThesaurusService.java
+++ b/src/main/java/tla/backend/service/ThesaurusService.java
@@ -71,8 +71,8 @@ public class ThesaurusService extends UserFriendlyEntityService<ThsEntryEntity, 
     }
 
     @Override
-    public ESQueryBuilder getSearchCommandAdapter(SearchCommand<ThsEntryDto> command) {
-        return this.getModelMapper().map(command, ThsSearchQueryBuilder.class);
+    public Class<? extends ESQueryBuilder> getSearchCommandAdapterClass(SearchCommand<ThsEntryDto> command) {
+        return ThsSearchQueryBuilder.class;
     }
 
 }

--- a/src/main/java/tla/backend/service/component/EntityRetrieval.java
+++ b/src/main/java/tla/backend/service/component/EntityRetrieval.java
@@ -30,6 +30,11 @@ public class EntityRetrieval {
             this.refs = new HashMap<>();
         }
 
+        /**
+         * creates a new bulk entity resolver instance and initialize it
+         * with given collection of object reference items to be resolved to actual
+         * entities.
+         */
         public static BulkEntityResolver of(Collection<? extends Resolvable> references) {
             return new BulkEntityResolver().addAll(references);
         }
@@ -45,6 +50,30 @@ public class EntityRetrieval {
                     e -> bulk.addAll(e.getValue())
                 );
             }
+            return bulk;
+        }
+
+        /**
+         * creates a bulk entity resolver and initialize it with the object references
+         * from all given entities' relations.
+         */
+        public static BulkEntityResolver from(Collection<LinkedEntity> entities) {
+            return BulkEntityResolver.from(entities.stream());
+        }
+
+        /**
+         * creates a bulk entity resolver and initialize it with all object references
+         * found inside a stream of entities' relations.
+         */
+        public static BulkEntityResolver from(Stream<LinkedEntity> entities) {
+            var bulk = new BulkEntityResolver();
+            entities.forEach(
+                entity -> {
+                    entity.getRelations().entrySet().stream().forEach(
+                        entry -> bulk.addAll(entry.getValue())
+                    );
+                }
+            );
             return bulk;
         }
 

--- a/src/main/java/tla/backend/service/search/SearchService.java
+++ b/src/main/java/tla/backend/service/search/SearchService.java
@@ -43,6 +43,9 @@ public class SearchService {
             this.query = query;
         }
 
+        /**
+         * execute query after updating it with the results of executing its dependencies.
+         */
         public ESQueryResult<?> run(Pageable page) {
             log.info("run query for page {}", page);
             log.info("dependency: {}", this.query.getDependencies());

--- a/src/main/java/tla/backend/service/search/SearchService.java
+++ b/src/main/java/tla/backend/service/search/SearchService.java
@@ -75,6 +75,11 @@ public class SearchService {
     @Autowired
     protected RestHighLevelClient restClient;
 
+    /**
+     * Creates a new {@link QueryExecutor} for a given query.
+     *
+     * TODO: actual registry?
+     */
     public QueryExecutor register(ESQueryBuilder query) {
         return new QueryExecutor(query);
     }

--- a/src/main/java/tla/backend/service/search/SearchService.java
+++ b/src/main/java/tla/backend/service/search/SearchService.java
@@ -198,5 +198,4 @@ public class SearchService {
         }
     }
 
-
 }

--- a/src/test/java/tla/backend/api/ApiControllerTest.java
+++ b/src/test/java/tla/backend/api/ApiControllerTest.java
@@ -1,0 +1,71 @@
+package tla.backend.api;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import tla.backend.AbstractMockMvcTest;
+import tla.backend.es.model.Metadata;
+import tla.backend.es.model.parts.EditDate;
+import tla.backend.es.repo.MetadataRepo;
+
+public class ApiControllerTest extends AbstractMockMvcTest {
+
+    @MockBean
+    private MetadataRepo metadataRepo;
+
+    @Autowired
+    private BuildProperties buildProperties;
+
+    @Test
+    void queryEndpointList() throws Exception {
+        final var expectedPaths = List.of(
+            "/lemma/count",
+            "/version",
+            "/ths/get/{id}"
+        );
+        var response = mockMvc.perform(get("/")).andExpect(
+            status().isOk()
+        ).andReturn();
+        var content = response.getResponse().getContentAsString();
+        assertAll("check for expected endpoint paths",
+            expectedPaths.stream().map(
+                path -> () -> assertTrue(content.contains(path), path)
+            )
+        );
+    }
+
+    @Test
+    void queryVersionEndpoint() throws Exception {
+        var info = new Metadata();
+        info.setDOI("10.5072/zenodo.716586");
+        info.setId("v1.0.210115");
+        info.setDate(EditDate.of(2021, 01, 15));
+        info.setModelVersion("0.1.253-dev");
+        info.setEtlVersion("0.1.280");
+        info.setLingglossVersion("0.0.2");
+        when(metadataRepo.findAll()).thenReturn(
+            List.of(info)
+        );
+        mockMvc.perform(get("/version")).andExpect(
+            status().isOk()
+        ).andExpect(
+            jsonPath("$.version").value(buildProperties.getVersion())
+        ).andExpect(
+            jsonPath("$.release").value(info.getId())
+        ).andExpect(
+            jsonPath("$.date").value(EditDate.DATE_CONVERTER.format(info.getDate()))
+        ).andExpect(
+            jsonPath("$.etlVersion").value(info.getEtlVersion())
+        );
+    }
+
+}

--- a/src/test/java/tla/backend/api/LemmaControllerTest.java
+++ b/src/test/java/tla/backend/api/LemmaControllerTest.java
@@ -70,10 +70,9 @@ public class LemmaControllerTest extends AbstractMockMvcTest {
             .build();
         String ser = new ObjectMapper().writeValueAsString(l1);
         LemmaEntity l2 = mapper.readValue(ser, LemmaEntity.class);
-        assertAll("lemma instance created via lombok builder should be the same after being serialized by object mapper and deserialized by ES entity mapper",
-            () -> assertEquals(l1, l2, "equals should return true"),
+        assertAll("lemma created via lombok builder should be the same after being serialized by object mapper and deserialized by ES entity mapper",
+            () -> assertEquals(l1.toString(), l2.toString(), "toString equal"),
             () -> assertEquals(mapper.writeValueAsString(l1), mapper.writeValueAsString(l2), "ES entity mapper serializations should be equal"),
-            () -> assertEquals(l1.hashCode(), l2.hashCode(), "hashCode should return equals"),
             () -> assertNotNull(l2.getWords().get(0).getTranscription(), "expect word transcription")
         );
     }

--- a/src/test/java/tla/backend/es/model/ModelTest.java
+++ b/src/test/java/tla/backend/es/model/ModelTest.java
@@ -185,7 +185,8 @@ public class ModelTest {
         assertAll("thesaurus entry instances should be equal regardless of creation method",
             () -> assertNotEquals(t_built, t_read, "deserialized instance should not be the same as built instance"),
             () -> assertEquals(t_built, t_round, "built instance should remain the same after serialization and deserialization via ES entity mapper"),
-            () -> assertEquals(t_built.getEditors(), t_read.getEditors(), "edit infos should be equal")
+            () -> assertEquals(t_built.getEditors(), t_read.getEditors(), "edit infos should be equal"),
+            () -> assertEquals(t_built.hashCode(), t_round.hashCode(), "hashcode same after deserializing serialization")
         );
     }
 
@@ -242,7 +243,8 @@ public class ModelTest {
             () -> assertEquals("BTSLemmaEntry", l_built.getEclass(), "superclass getEclass() method should return registered eClass value"),
             () -> assertEquals(IO.json(l_built), IO.json(l_round)),
             () -> assertEquals(l_built, l_read, "deserialized lemma instance should be equal to built instance with the same properties"),
-            () -> assertEquals(l_built, l_round, "lemma instance serialized and then deserialized should equal itself")
+            () -> assertEquals(l_built, l_round, "lemma instance serialized and then deserialized should equal itself"),
+            () -> assertEquals(l_built.hashCode(), l_round.hashCode(), "hashcode stays the same after deserializing serialization")
         );
     }
 

--- a/src/test/java/tla/backend/es/model/ModelTest.java
+++ b/src/test/java/tla/backend/es/model/ModelTest.java
@@ -19,8 +19,6 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.Test;
-import org.modelmapper.AbstractConverter;
-import org.modelmapper.ModelMapper;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.elasticsearch.annotations.Document;
 
@@ -37,11 +35,8 @@ import tla.backend.es.model.parts.PartOfSpeech;
 import tla.backend.es.model.parts.Token;
 import tla.backend.es.model.parts.Token.Flexion;
 import tla.backend.es.model.parts.Token.Lemmatization;
-import tla.backend.es.query.TextSearchQueryBuilder;
 import tla.backend.es.model.parts.Transcription;
 import tla.backend.es.model.parts.Translations;
-import tla.domain.command.PassportSpec;
-import tla.domain.command.TextSearch;
 import tla.domain.dto.AnnotationDto;
 import tla.domain.dto.CorpusObjectDto;
 import tla.domain.dto.LemmaDto;
@@ -568,32 +563,6 @@ public class ModelTest {
             () -> assertNotNull(tdto.getLemma().getPartOfSpeech().getType(), "lemma POS type"),
             () -> assertTrue(tdto.getAnnoTypes().contains("rubrum"), "token is rubrum")
         );
-    }
-
-    @Test
-    void passportSearchCommandMapping() {
-        var modelMapper = new ModelMapper();
-        PassportSpec pp = new PassportSpec();
-        pp.put("date", PassportSpec.ThsRefPassportValue.of(List.of("XX"), true));
-        var ppp = modelMapper.map(pp, PassportSpec.class);
-        assertNotNull(ppp);
-        modelMapper.createTypeMap(PassportSpec.class, PassportSpec.class);
-        modelMapper.createTypeMap(TextSearch.class, TextSearchQueryBuilder.class).addMappings(
-            m -> m.using(
-                new AbstractConverter<PassportSpec,PassportSpec>(){
-                    protected PassportSpec convert(PassportSpec source) {
-                        return source;
-                    }
-                }
-            ).map(
-                TextSearch::getPassport, TextSearchQueryBuilder::setPassport
-            )
-        );
-        TextSearch command = new TextSearch();
-        command.setPassport(pp);
-        var ttt = modelMapper.map(command, TextSearchQueryBuilder.class);
-        assertNotNull(ttt.getPassport());
-        assertEquals(1, ttt.getPassport().size());
     }
 
 }

--- a/src/test/java/tla/backend/es/model/meta/MappingTest.java
+++ b/src/test/java/tla/backend/es/model/meta/MappingTest.java
@@ -1,0 +1,46 @@
+package tla.backend.es.model.meta;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import tla.backend.es.query.SentenceSearchQueryBuilder;
+import tla.backend.es.query.TextSearchQueryBuilder;
+import tla.domain.command.PassportSpec;
+import tla.domain.command.SentenceSearch;
+import tla.domain.command.TextSearch;
+
+public class MappingTest {
+
+    @BeforeEach
+    void initModelMapper() {
+        ModelConfig.initModelMapper();
+    }
+
+    @Test
+    void passportSearchCommandMapping() {
+        var modelMapper = ModelConfig.modelMapper;
+        PassportSpec pp = new PassportSpec();
+        pp.put("date", PassportSpec.ThsRefPassportValue.of(List.of("XX"), true));
+        var ppp = modelMapper.map(pp, PassportSpec.class);
+        assertNotNull(ppp);
+        TextSearch command = new TextSearch();
+        command.setPassport(pp);
+        var ttt = modelMapper.map(command, TextSearchQueryBuilder.class);
+        assertNotNull(ttt.getPassport());
+        assertEquals(1, ttt.getPassport().size());
+    }
+
+    @Test
+    void sentenceSearchCommandMapping() {
+        SentenceSearch cmd = new SentenceSearch();
+        var modelMapper = ModelConfig.modelMapper;
+        var qb = modelMapper.map(cmd, SentenceSearchQueryBuilder.class);
+        assertNotNull(qb);
+    }
+
+}

--- a/src/test/java/tla/backend/es/model/meta/MappingTest.java
+++ b/src/test/java/tla/backend/es/model/meta/MappingTest.java
@@ -5,8 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.modelmapper.ModelMapper;
 
 import tla.backend.es.query.SentenceSearchQueryBuilder;
 import tla.backend.es.query.TextSearchQueryBuilder;
@@ -14,16 +17,25 @@ import tla.domain.command.PassportSpec;
 import tla.domain.command.SentenceSearch;
 import tla.domain.command.TextSearch;
 
+@TestInstance(Lifecycle.PER_CLASS)
 public class MappingTest {
 
-    @BeforeEach
-    void initModelMapper() {
-        ModelConfig.initModelMapper();
+    private ModelMapper modelMapper;
+
+    public ModelMapper getModelMapper() {
+        if (modelMapper == null) {
+            modelMapper = ModelConfig.initModelMapper();
+        }
+        return modelMapper;
+    }
+
+    @BeforeAll
+    void init() {
+        getModelMapper();
     }
 
     @Test
     void passportSearchCommandMapping() {
-        var modelMapper = ModelConfig.modelMapper;
         PassportSpec pp = new PassportSpec();
         pp.put("date", PassportSpec.ThsRefPassportValue.of(List.of("XX"), true));
         var ppp = modelMapper.map(pp, PassportSpec.class);
@@ -38,7 +50,6 @@ public class MappingTest {
     @Test
     void sentenceSearchCommandMapping() {
         SentenceSearch cmd = new SentenceSearch();
-        var modelMapper = ModelConfig.modelMapper;
         var qb = modelMapper.map(cmd, SentenceSearchQueryBuilder.class);
         assertNotNull(qb);
     }

--- a/src/test/java/tla/backend/es/query/SearchCommandQueryBuilderTest.java
+++ b/src/test/java/tla/backend/es/query/SearchCommandQueryBuilderTest.java
@@ -1,0 +1,79 @@
+package tla.backend.es.query;
+
+import static com.jayway.jsonpath.JsonPath.read;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import com.jayway.jsonpath.Configuration;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.modelmapper.ModelMapper;
+
+import tla.backend.es.model.meta.MappingTest;
+import tla.domain.command.LemmaSearch;
+import tla.domain.command.SentenceSearch;
+import tla.domain.command.TranslationSpec;
+import tla.domain.command.TypeSpec;
+import tla.domain.model.Language;
+import tla.domain.model.Script;
+
+@TestInstance(Lifecycle.PER_CLASS)
+public class SearchCommandQueryBuilderTest {
+
+    ModelMapper modelMapper;
+
+    @BeforeAll
+    void initModelMapper() {
+        modelMapper = new MappingTest().getModelMapper();
+    }
+
+    static Object toJson(TLAQueryBuilder query) {
+        return Configuration.defaultConfiguration().jsonProvider().parse(
+            query.toJson()
+        );
+    }
+
+    @Test
+    void lemmaSearchQueryTest() throws Exception {
+        LemmaSearch cmd = new LemmaSearch();
+        cmd.setWordClass(new TypeSpec("type", "subtype"));
+        cmd.setScript(new Script[]{Script.DEMOTIC});
+        var query = modelMapper.map(cmd, LemmaSearchQueryBuilder.class);
+        var json = toJson(query);
+        assertAll("lemma search ES query",
+            //() -> assertEquals("", query.toJson()),
+            () -> assertEquals(List.of("type"), read(json, "$.bool.must[*].bool.must[*].term.type.value"), "type term query"),
+            () -> assertEquals(List.of("d"), read(json, "$.bool.filter[*].bool.must[*].prefix.id.value"), "prefix for demotic IDs")
+        );
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    void sentenceSeachQueryTest() throws Exception {
+        SentenceSearch cmd = new SentenceSearch();
+        cmd.setTranslation(new TranslationSpec());
+        cmd.getTranslation().setText("horse");
+        cmd.getTranslation().setLang(new Language[]{Language.DE, Language.EN});
+        SentenceSearch.TokenSpec t = new SentenceSearch.TokenSpec();
+        t.setTranslation(new TranslationSpec());
+        t.getTranslation().setText("pferd");
+        t.getTranslation().setLang(new Language[]{Language.DE});
+        cmd.setTokens(List.of(t));
+        var query = modelMapper.map(cmd, SentenceSearchQueryBuilder.class);
+        var json = toJson(query);
+        assertAll("sentence search ES query",
+            //() -> assertEquals("", query.toJson()),
+            () -> assertEquals(2, ((List)read(json, "$.bool.should[*].bool.should[*].match.keys()")).size()),
+            () -> assertEquals(
+                List.of("pferd"),
+                read(json, "$.bool.filter[*].nested.query.bool.should[*].bool.should[*].match['tokens.translations.de'].query")
+            )
+        );
+    }
+
+}

--- a/src/test/java/tla/backend/es/repo/RepoTest.java
+++ b/src/test/java/tla/backend/es/repo/RepoTest.java
@@ -50,7 +50,7 @@ public class RepoTest {
 
     @Test
     void repoPopulatorHasRegistry() {
-        final var expectedKeys = List.of("lemma", "ths", "text", "comment", "annotation", "object", "sentence");
+        final var expectedKeys = List.of("lemma", "ths", "text", "comment", "annotation", "object", "sentence", "meta");
         assertTrue(ModelConfig.isInitialized(), "entity model registered");
         repoPopulator.init();
         assertAll(

--- a/src/test/java/tla/backend/service/SentenceServiceTest.java
+++ b/src/test/java/tla/backend/service/SentenceServiceTest.java
@@ -1,19 +1,30 @@
 package tla.backend.service;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
 
+import org.elasticsearch.common.collect.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.SearchHitsImpl;
+import org.springframework.data.elasticsearch.core.TotalHitsRelation;
 
 import tla.backend.App;
 import tla.backend.Util;
@@ -25,7 +36,11 @@ import tla.backend.es.repo.AnnotationRepo;
 import tla.backend.es.repo.SentenceRepo;
 import tla.backend.es.repo.TextRepo;
 import tla.backend.es.repo.ThesaurusRepo;
+import tla.domain.command.SentenceSearch;
+import tla.domain.command.TranslationSpec;
+import tla.domain.dto.extern.SearchResultsWrapper;
 import tla.domain.dto.extern.SingleDocumentWrapper;
+import tla.domain.model.Language;
 
 @SpringBootTest(classes = {App.class})
 public class SentenceServiceTest {
@@ -44,6 +59,61 @@ public class SentenceServiceTest {
 
     @Autowired
     private SentenceService sentenceService;
+
+    @MockBean
+    private ElasticsearchOperations operations;
+
+    @Test
+    void getSentenceSearchResultsWrapper() throws Exception {
+        String textId = "CDWYGHBII5C37IBETSSI6RCIDQ";
+        var text = Util.loadSampleFile(TextEntity.class, textId);
+        when(
+            textRepo.findAllById(anyCollection())
+        ).thenReturn(
+            List.of(
+                text
+            )
+        );
+        String annoId = "IBUBd0kXx8hvzU9vuxAKWNHnf6s";
+        var rubrum = Util.loadSampleFile(AnnotationEntity.class, annoId);
+        when(
+            annoRepo.findAllById(anyCollection())
+        ).thenReturn(
+            List.of(rubrum)
+        );
+        SentenceEntity s = Util.loadSampleFile(SentenceEntity.class, "IBUBd3QvPWhrgk50h3u3Wv5PmdA");
+        SearchHit<SentenceEntity> hit = new SearchHit<>(null, null, 1f, null, null, null, null, s);
+        SearchHits<SentenceEntity> hits = new SearchHitsImpl<>(1, TotalHitsRelation.EQUAL_TO, 1f, null, List.of(hit), null);
+        SentenceSearch cmd = new SentenceSearch();
+        TranslationSpec translation = new TranslationSpec();
+        translation.setText("Blut der ersten Geburt der Kobra");
+        translation.setLang(new Language[]{Language.DE});
+        cmd.setTranslation(translation);
+        var query = sentenceService.getSearchCommandAdapter(cmd);
+        assertNotNull(query);
+        when(
+            operations.search(
+                any(org.springframework.data.elasticsearch.core.query.Query.class),
+                eq(SentenceEntity.class),
+                any()
+            )
+        ).thenReturn(
+            hits
+        );
+        SearchResultsWrapper<?> dto = sentenceService.runSearchCommand(cmd, PageRequest.of(1, 20)).orElseThrow();
+        assertAll("test search results in container",
+            () -> assertNotNull(dto.getResults(), "contains results"),
+            () -> assertEquals(1, dto.getResults().size(), "exactly 1 sentence")
+        );
+        assertAll("test sentence search results container",
+            () -> assertNotNull(dto.getRelated(), "related objects"),
+            () -> assertEquals(Set.of("BTSText", "BTSAnnotation"), dto.getRelated().keySet(), "both partOf and contains objects injected"),
+            () -> assertEquals(Set.of(textId), dto.getRelated().get("BTSText").keySet(), "1 related text"),
+            () -> assertNull(dto.getRelated().get("BTSComment"), "no comments"),
+            () -> assertEquals(text.toDTO().toJson(), dto.getRelated().get("BTSText").get(textId).toJson(), "text as expected"),
+            () -> assertEquals(rubrum.toDTO().toJson(), dto.getRelated().get("BTSAnnotation").get(annoId).toJson(), "rubrum as expected")
+        );
+    }
 
     @Test
     void getSentenceDetailsWrapper() throws Exception {


### PR DESCRIPTION
additional improvements:
- import corpus dump metadata and add it to `/version` endpoint
- handle translation query specifiers in nested token query builder
- better test coverage