### PR TITLE
Integrated Search Engine Test System

### DIFF
--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -1,0 +1,46 @@
+name: searchtest
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - name: Set up Elasticsearch container
+      run: docker-compose up -d es
+      env:
+        ES_PORT: 9200
+
+    - name: Wait for ES to respond
+      uses: cygnetdigital/wait_for_response@v2.0.0
+      with:
+        url: 'http://localhost:9200'
+        responseCode: '200'
+        timeout: 30000
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Ingest corpus data
+      run: ./gradlew populate
+      env:
+        ES_PORT: 9200
+        SAMPLE_URL: http://aaew64.bbaw.de/resources/tla-data/tla-sample-20210115-1000t.tar.gz
+
+    - name: Run search tests
+      run: ./gradlew searchTest
+      env:
+        ES_PORT: 9200
+
+    - uses: ashley-taylor/junit-report-annotations-action@master
+      with:
+        access-token: ${{ secrets.GITHUB_TOKEN }}
+      if: always()

--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -3,7 +3,7 @@ name: searchtest
 on: [push, pull_request]
 
 jobs:
-  build:
+  search:
     runs-on: ubuntu-latest
 
     steps:
@@ -26,6 +26,16 @@ jobs:
         responseCode: '200'
         timeout: 30000
 
+    - name: Cache sample corpus data
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-corpus-data
+      with:
+        path: sample.tar.gz
+        key: ${{ runner.os }}-searchtest-${{ env.cache-name }}-${{ hashFiles('sample.tar.gz') }}
+        restore-keys: |
+          ${{ runner.os }}-searchtest-${{ env.cache-name }}-
+
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
@@ -33,7 +43,7 @@ jobs:
       run: ./gradlew populate
       env:
         ES_PORT: 9200
-        SAMPLE_URL: http://aaew64.bbaw.de/resources/tla-data/tla-sample-20210115-1000t.tar.gz
+        SAMPLE_URL: http://aaew64.bbaw.de/resources/tla-data/tla-data-20210115.tar.gz
 
     - name: Run search tests
       run: ./gradlew searchTest

--- a/.github/workflows/search.yml
+++ b/.github/workflows/search.yml
@@ -1,6 +1,6 @@
 name: searchtest
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   search:
@@ -46,7 +46,7 @@ jobs:
         SAMPLE_URL: http://aaew64.bbaw.de/resources/tla-data/tla-data-20210115.tar.gz
 
     - name: Run search tests
-      run: ./gradlew searchTest
+      run: ./gradlew testSearch
       env:
         ES_PORT: 9200
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ settings.gradle
 *.csv
 *.gv
 *.pdf
-*.json
+/*.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:6.8.1-jdk11 AS build
+FROM gradle:7.0.0-jdk11 AS build
 
 COPY --chown=gradle:gradle . /home/gradle/tla
 WORKDIR /home/gradle/tla

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ![build](https://github.com/jkatzwinkel/tla-es/workflows/build/badge.svg)
 ![deploy](https://github.com/jkatzwinkel/tla-es/workflows/deploy/badge.svg)
+![search](https://github.com/jkatzwinkel/tla-es/workflows/searchtest/badge.svg)
 ![LINE](https://img.shields.io/badge/line--coverage-68%25-yellow.svg)
-![METHOD](https://img.shields.io/badge/method--coverage-76%25-yellow.svg)
+![METHOD](https://img.shields.io/badge/method--coverage-75%25-yellow.svg)
 
 # tla-es
 
@@ -101,6 +102,30 @@ Run the app using the `bootRun` task:
     ./gradlew bootrun
 
 > If you are on a Windows machine, you need to execute the `gradlew.bat` wrapper shipped with this repository.
+
+
+## Tests
+
+There are 3 Gradle tasks for running tests:
+
+- `:test`: run unit tests
+- `:testSearch`: run search tests against live Elasticsearch instance
+- `:testAll`: run all of those tests
+
+Note that due to the way Spring-Data works, there is an Elasticsearch instance required even for the unit tests,
+although it may well be entirely empty. For the search tests however, the Elasticsearch instance must be fully
+populated so that search results can actually be verified against the specified expectations. This means you must
+have executed the `:populate` task (`./gradlew populate`) prior executing `:testSearch` or `:testAll`.
+
+Search tests are being performed based on search scenarios specified in JSON files. The specification model can be
+found in [`SearchTestSpecs.java`](src/test/java/tla/backend/search/SearchTestSpecs.java). Individual specification
+instances consist of at least a name and a search command. JSON files containing a list of several search test
+specifications have to be located within the classpath directory set via the
+[application property](src/test/resources/application-test.yml) `tla.searchtest.path`, each under a sub-directory
+whose name can be used to identify the entity service to be used to execute the contained search commands.
+The paths used to identify the entity services can be found in the `@ModelClass` annotations of the entity services.
+
+Test runs create JUnit and Jacoco reports at the usual output locations.
 
 
 ## Misc

--- a/build.gradle
+++ b/build.gradle
@@ -6,13 +6,13 @@ plugins {
     id 'maven-publish'
     id 'co.uzzu.dotenv.gradle' version '1.1.0'
     id 'de.undercouch.download' version '4.1.1'
-    id 'org.springframework.boot' version '2.4.2'
-    id 'com.github.ben-manes.versions' version '0.36.0'
+    id 'org.springframework.boot' version '2.4.5'
+    id 'com.github.ben-manes.versions' version '0.38.0'
     id 'com.github.dawnwords.jacoco.badge' version '0.2.0'
 }
 
 group = 'org.bbaw.aaew.tla'
-version = '0.0.832'
+version = '0.0.833'
 sourceCompatibility = '11'
 
 publishing {
@@ -54,16 +54,17 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.20'
 
     implementation 'com.github.jkatzwinkel:tla-common:query-expansion-SNAPSHOT'
-    implementation 'org.modelmapper:modelmapper:2.4.0'
+    implementation 'org.modelmapper:modelmapper:2.4.1'
     implementation 'org.apache.commons:commons-compress:1.20'
     implementation 'org.apache.tomcat.embed:tomcat-embed-core:9.0.35'
     implementation 'org.yaml:snakeyaml:1.28'
 
-    implementation 'org.springframework.data:spring-data-elasticsearch:4.2.0-M1'
     implementation 'org.springframework.boot:spring-boot:2.5.0-M1'
     implementation 'org.springframework.boot:spring-boot-autoconfigure:2.5.0-M1'
-    implementation 'org.springframework:spring-web:5.3.3'
-    implementation 'org.springframework:spring-webmvc:5.3.3'
+    implementation 'org.springframework.data:spring-data-elasticsearch:4.2.0-M1'
+    implementation 'org.springframework:spring-web:5.3.6'
+    implementation 'org.springframework:spring-webmvc:5.3.6'
+    implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
     implementation 'org.slf4j:slf4j-simple:2.0.0-alpha1'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.5.0-M3'

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ test {
     finalizedBy 'jacocoTestReport'
 }
 
-task searchTest(type: Test) {
+task testSearch(type: Test) {
     group = 'Verification'
     description = 'Runs search integration tests against populated ES instance.'
     systemProperty 'spring.profiles.active', 'search'
@@ -91,6 +91,14 @@ task searchTest(type: Test) {
     useJUnitPlatform {
       includeTags 'search'
     }
+}
+
+task testAll(type: Test) {
+    group = 'Verification'
+		description = 'Runs both search integration and unit tests.'
+    useJUnitPlatform()
+    environment "ES_PORT", env.fetch("ES_PORT", "9200")
+    finalizedBy 'jacocoTestReport'
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'org.bbaw.aaew.tla'
-version = '0.0.830'
+version = '0.0.832'
 sourceCompatibility = '11'
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -49,14 +49,15 @@ configurations {
 }
 
 dependencies {
-    compileOnly 'org.projectlombok:lombok:1.18.18'
-    annotationProcessor 'org.projectlombok:lombok:1.18.18'
+    implementation 'org.projectlombok:lombok:1.18.20'
+    annotationProcessor 'org.projectlombok:lombok:1.18.20'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.20'
 
     implementation 'com.github.jkatzwinkel:tla-common:query-expansion-SNAPSHOT'
-    implementation 'org.modelmapper:modelmapper:2.3.9'
+    implementation 'org.modelmapper:modelmapper:2.4.0'
     implementation 'org.apache.commons:commons-compress:1.20'
     implementation 'org.apache.tomcat.embed:tomcat-embed-core:9.0.35'
-    implementation 'org.yaml:snakeyaml:1.27'
+    implementation 'org.yaml:snakeyaml:1.28'
 
     implementation 'org.springframework.data:spring-data-elasticsearch:4.2.0-M1'
     implementation 'org.springframework.boot:spring-boot:2.5.0-M1'
@@ -65,8 +66,9 @@ dependencies {
     implementation 'org.springframework:spring-webmvc:5.3.3'
     implementation 'org.slf4j:slf4j-simple:2.0.0-alpha1'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.5.0-M1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.5.0-M3'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.0-M1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.0-M1'
 }
 
 application {
@@ -74,9 +76,21 @@ application {
 }
 
 test {
-    useJUnitPlatform()
+    useJUnitPlatform{
+      includeTags '!search'
+    }
     environment "ES_PORT", env.fetch("ES_PORT", "9200")
     finalizedBy 'jacocoTestReport'
+}
+
+task searchTest(type: Test) {
+    group = 'Verification'
+    description = 'Runs search integration tests against populated ES instance.'
+    systemProperty 'spring.profiles.active', 'search'
+    environment "ES_PORT", env.fetch("ES_PORT", "9200")
+    useJUnitPlatform {
+      includeTags 'search'
+    }
 }
 
 jacocoTestReport {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/java/META-INF/additional-spring-configuration-metadata.json
@@ -10,6 +10,10 @@
         {
             "name": "tla.es",
             "type": "tla.backend.config.ApplicationProperties.ElasticsearchProperties"
+        },
+        {
+            "name": "tla.searchtest",
+            "type": "java.util.Map"
         }
     ]
 }

--- a/src/main/java/tla/backend/es/model/parts/Token.java
+++ b/src/main/java/tla/backend/es/model/parts/Token.java
@@ -114,7 +114,7 @@ public class Token {
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Glyphs {
-        @Field(type = FieldType.Text, analyzer = "hieroglyph_analyzer")
+        @Field(type = FieldType.Text, analyzer = "hieroglyph_analyzer", searchAnalyzer = "hieroglyph_analyzer")
         private String mdc;
 
         @Field(type = FieldType.Text)

--- a/src/main/java/tla/backend/es/model/parts/Transcription.java
+++ b/src/main/java/tla/backend/es/model/parts/Transcription.java
@@ -19,11 +19,10 @@ import lombok.Setter;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Transcription {
 
-    @Field(type = FieldType.Text, analyzer = "transcription_analyzer")
+    @Field(type = FieldType.Text, analyzer = "transcription_analyzer", searchAnalyzer = "transcription_analyzer")
     private String unicode;
 
-    @Field(type = FieldType.Text, analyzer = "transcription_analyzer")
+    @Field(type = FieldType.Text, analyzer = "transcription_analyzer", searchAnalyzer = "transcription_analyzer")
     private String mdc;
 
-    //TODO hieroglyphs?
 }

--- a/src/main/java/tla/backend/es/query/LemmaSearchQueryBuilder.java
+++ b/src/main/java/tla/backend/es/query/LemmaSearchQueryBuilder.java
@@ -47,7 +47,7 @@ public class LemmaSearchQueryBuilder extends ESQueryBuilder implements MultiLing
 
     public void setTranscription(String transcription) {
         if (transcription != null) {
-            this.must(matchQuery("name", transcription));
+            this.must(matchQuery("words.transcription.unicode", transcription));
         }
     }
 

--- a/src/main/java/tla/backend/es/query/MultiLingQueryBuilder.java
+++ b/src/main/java/tla/backend/es/query/MultiLingQueryBuilder.java
@@ -26,7 +26,7 @@ public interface MultiLingQueryBuilder extends TLAQueryBuilder {
                 );
             }
         }
-        this.should(translationsQuery);
+        this.filter(translationsQuery);
     }
 
 }

--- a/src/main/java/tla/backend/es/query/SentenceSearchQueryBuilder.java
+++ b/src/main/java/tla/backend/es/query/SentenceSearchQueryBuilder.java
@@ -2,7 +2,10 @@ package tla.backend.es.query;
 
 import java.util.Collection;
 
+import static org.elasticsearch.index.query.QueryBuilders.*;
+
 import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 
 import lombok.Getter;
@@ -17,9 +20,10 @@ import tla.domain.command.PassportSpec;
 public class SentenceSearchQueryBuilder extends ESQueryBuilder implements MultiLingQueryBuilder {
 
     public void setTokens(Collection<TokenSearchQueryBuilder> tokenQueries) {
+        BoolQueryBuilder tokenQuery = boolQuery();
         if (tokenQueries != null) {
             tokenQueries.forEach(
-                query -> this.filter(
+                query -> tokenQuery.must(
                     QueryBuilders.nestedQuery(
                         "tokens",
                         query.getNativeRootQueryBuilder(),
@@ -28,6 +32,7 @@ public class SentenceSearchQueryBuilder extends ESQueryBuilder implements MultiL
                 )
             );
         }
+        this.filter(tokenQuery);
     }
 
     public void setPassport(PassportSpec spec) {

--- a/src/main/java/tla/backend/es/repo/RepoPopulator.java
+++ b/src/main/java/tla/backend/es/repo/RepoPopulator.java
@@ -16,6 +16,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import tla.backend.es.model.meta.Indexable;
 import tla.backend.service.ModelClass;
@@ -65,19 +66,17 @@ public class RepoPopulator {
         final static int MAX_BATCH_SIZE = 750;
 
         private List<S> batch;
+        @Getter private EntityService<S,?,?> service;
         private Class<S> modelClass;
         private String path;
         private int count;
 
         private ObjectMapper jsonMapper = new ObjectMapper();
 
-        public RepoBatchIngestor(Class<S> modelClass) {
-            this.modelClass = modelClass;
-            this.path = getModelClassServicePath(
-                EntityService.getService(
-                    modelClass.asSubclass(AbstractBTSBaseClass.class)
-                )
-            );
+        public RepoBatchIngestor(EntityService<S,?,?> service) {
+            this.service = service;
+            this.modelClass = service.getModelClass();
+            this.path = getModelClassServicePath(service);
             this.batch = new ArrayList<>();
             this.count = 0;
             log.info("set up batch ingestor for model class {}", modelClass.getName());
@@ -120,13 +119,10 @@ public class RepoPopulator {
          * same model class as this batch indexer is typed for, and uses that service's {@link ElasticsearchRepository}
          * to batch-index all entities currently in the cache.
          */
-        @SuppressWarnings("unchecked")
         public void ingest() {
             try {
                 (
-                    (ElasticsearchRepository<S, String>) EntityService.getService(
-                        modelClass.asSubclass(AbstractBTSBaseClass.class)
-                    ).getRepo()
+                    (ElasticsearchRepository<S, String>) service.getRepo()
                 ).saveAll(this.batch);
                 this.count += this.batch.size();
                 this.batch.clear();
@@ -169,6 +165,15 @@ public class RepoPopulator {
     }
 
     /**
+     * Find the entity service whose {@link ModelClass} annotation's <code>path</code> value equals
+     * the given <code>modelPath</code> parameter.
+     */
+    public EntityService<?,?,?> getService(String modelPath) {
+        return this.selectBatchIngestor(modelPath).getService();
+    }
+
+
+    /**
      * Registers {@link RepoBatchIngestor} instances for each model class for which an {@link EntityService}
      * subclass has been registered with the {@link ModelClass} annotation.
      * @return populator instance
@@ -176,16 +181,15 @@ public class RepoPopulator {
      */
     public RepoPopulator init() {
         for (Class<? extends Indexable> modelClass : EntityService.getRegisteredModelClasses()) {
+            var service = EntityService.getService(
+                modelClass.asSubclass(AbstractBTSBaseClass.class)
+            );
             if (AbstractBTSBaseClass.class.isAssignableFrom(modelClass)) {
-                String modelPath = getModelClassServicePath(
-                    EntityService.getService(
-                        modelClass.asSubclass(AbstractBTSBaseClass.class)
-                    )
-                );
+                String modelPath = getModelClassServicePath(service);
                 if (modelPath != null && !modelPath.isEmpty()) {
                     this.repoIngestors.put(
                         modelPath,
-                        new RepoBatchIngestor<>(modelClass)
+                        new RepoBatchIngestor<>(service)
                     );
                 }
             }

--- a/src/main/resources/elasticsearch/settings/indices/lemma.json
+++ b/src/main/resources/elasticsearch/settings/indices/lemma.json
@@ -28,7 +28,7 @@
       "char_filter": {
         "transcription_brackets_filter": {
           "type": "pattern_replace",
-          "pattern": "\\.\\S+|[\\(\\)\\[\\]⸢⸮?⸣]|\\{\\S*\\}",
+          "pattern": "\\.[^- ]*|[\\(\\)\\[\\]⸢⸮?⸣]|\\{\\S*\\}",
           "replacement": ""
         },
         "transcription_suffix_filter": {

--- a/src/main/resources/elasticsearch/settings/indices/sentence.json
+++ b/src/main/resources/elasticsearch/settings/indices/sentence.json
@@ -27,7 +27,7 @@
         "char_filter": {
           "transcription_brackets_filter": {
             "type": "pattern_replace",
-            "pattern": "\\.\\S+|[\\(\\)\\[\\]⸢⸮?⸣]|\\{\\S*\\}",
+            "pattern": "\\.[^- ]*|[\\(\\)\\[\\]⸢⸮?⸣]|\\{\\S*\\}",
             "replacement": ""
           },
           "transcription_suffix_filter": {

--- a/src/test/java/tla/backend/es/query/SearchCommandQueryBuilderTest.java
+++ b/src/test/java/tla/backend/es/query/SearchCommandQueryBuilderTest.java
@@ -54,7 +54,7 @@ public class SearchCommandQueryBuilderTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    void sentenceSeachQueryTest() throws Exception {
+    void sentenceSearchQueryTest() throws Exception {
         SentenceSearch cmd = new SentenceSearch();
         cmd.setTranslation(new TranslationSpec());
         cmd.getTranslation().setText("horse");
@@ -67,11 +67,17 @@ public class SearchCommandQueryBuilderTest {
         var query = modelMapper.map(cmd, SentenceSearchQueryBuilder.class);
         var json = toJson(query);
         assertAll("sentence search ES query",
-            //() -> assertEquals("", query.toJson()),
-            () -> assertEquals(2, ((List)read(json, "$.bool.should[*].bool.should[*].match.keys()")).size()),
+            () -> assertEquals(
+                2, ((List)read(json, "$.bool.filter[*].bool.should[*].match.keys()")).size(),
+                "2 query clauses for sentence translation"
+            ),
             () -> assertEquals(
                 List.of("pferd"),
-                read(json, "$.bool.filter[*].nested.query.bool.should[*].bool.should[*].match['tokens.translations.de'].query")
+                read(
+                    json,
+                    "$.bool.filter[*].bool.must[*].nested.query.bool.filter[*].bool.should[*].match['tokens.translations.de'].query"
+                ),
+                "nested token translation filter query clause"
             )
         );
     }

--- a/src/test/java/tla/backend/search/SearchTest.java
+++ b/src/test/java/tla/backend/search/SearchTest.java
@@ -1,0 +1,95 @@
+package tla.backend.search;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import tla.backend.App;
+import tla.backend.es.model.LemmaEntity;
+import tla.backend.es.model.meta.Indexable;
+import tla.backend.es.model.meta.ModelConfig;
+import tla.backend.service.EntityService;
+import tla.domain.command.SearchCommand;
+import tla.domain.dto.extern.SearchResultsWrapper;
+import tla.domain.model.meta.AbstractBTSBaseClass;
+
+@Tag("search")
+@SpringBootTest(classes = {App.class})
+public class SearchTest {
+
+    public static final Pageable PAGE_1 = PageRequest.of(0, 20);
+
+    private static Stream<Arguments> testSpecs() throws Exception {
+        SearchTestSpecs[] scenarios = tla.domain.util.IO.loadFromFile(
+            "src/test/resources/search/tests.json",
+            SearchTestSpecs[].class
+        );
+        return Arrays.stream(scenarios).map(
+            specs -> Arguments.of(Named.of(specs.getName(), specs))
+        );
+    }
+
+    public EntityService<?,?,?> getService(Class<? extends AbstractBTSBaseClass> dtoClass) {
+        for (Class<? extends Indexable> modelClass : EntityService.getRegisteredModelClasses()) {
+            if (ModelConfig.getModelClassDTO(modelClass).equals(dtoClass)) {
+                if (AbstractBTSBaseClass.class.isAssignableFrom(modelClass)) {
+                    return EntityService.getService(
+                        modelClass.asSubclass(AbstractBTSBaseClass.class)
+                    );
+                }
+            }
+        }
+        return null;
+    }
+
+    @Test
+    void registryReady() {
+        assertTrue(ModelConfig.isInitialized(), "model class registry is initialized");
+        assertTrue(ModelConfig.getModelClasses().contains(LemmaEntity.class), "lemma model registered");
+        assertTrue(EntityService.getRegisteredModelClasses().size() > 3, "service registry ready");
+    }
+
+    @ParameterizedTest(name = "{index}: {0}")
+    @MethodSource("testSpecs")
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void searchTest(SearchTestSpecs testSpecs) throws Exception {
+        SearchCommand cmd = testSpecs.getCmd();
+        EntityService<?,?,?> service = getService(cmd.getDTOClass());
+        assertNotNull(cmd);
+        SearchResultsWrapper<?> result = (SearchResultsWrapper) service.runSearchCommand(cmd, PAGE_1).get();
+        testSpecs.getValid().forEach(
+            valid -> {
+                assertTrue(
+                    result.getResults().stream().anyMatch(
+                        dto -> dto.getId().equals(valid)
+                    ),
+                    "expect ID to be found: " + valid
+                );
+            }
+        );
+        testSpecs.getInvalid().forEach(
+            invalid -> {
+                assertFalse(
+                    result.getResults().stream().anyMatch(
+                        dto -> dto.getId().equals(invalid)
+                    ),
+                    "expect ID not to be found: " + invalid
+                );
+            }
+        );
+    }
+
+}

--- a/src/test/java/tla/backend/search/SearchTestSpecs.java
+++ b/src/test/java/tla/backend/search/SearchTestSpecs.java
@@ -12,12 +12,21 @@ import tla.domain.dto.meta.AbstractDto;
 @Setter
 public class SearchTestSpecs {
 
+    /**
+     * test displayname
+     */
     String name;
 
     SearchCommand<? extends AbstractDto> cmd;
 
+    /**
+     * IDs of expected search results.
+     */
     Collection<String> valid;
 
+    /**
+     * IDs of false positives.
+     */
     Collection<String> invalid;
 
     public SearchTestSpecs() {

--- a/src/test/java/tla/backend/search/SearchTestSpecs.java
+++ b/src/test/java/tla/backend/search/SearchTestSpecs.java
@@ -1,0 +1,28 @@
+package tla.backend.search;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import lombok.Getter;
+import lombok.Setter;
+import tla.domain.command.SearchCommand;
+import tla.domain.dto.meta.AbstractDto;
+
+@Getter
+@Setter
+public class SearchTestSpecs {
+
+    String name;
+
+    SearchCommand<? extends AbstractDto> cmd;
+
+    Collection<String> valid;
+
+    Collection<String> invalid;
+
+    public SearchTestSpecs() {
+        this.valid = Collections.emptyList();
+        this.invalid = Collections.emptyList();
+    }
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,7 @@
+---
+
+tla:
+  searchtest:
+    path: search
+
+...

--- a/src/test/resources/search/lemma/tests.json
+++ b/src/test/resources/search/lemma/tests.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "lemma - transcription: parenthesis ('()') should be ignored",
+    "name": "transcription: parenthesis ('()') should be ignored",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "(j)bkꜥ"
@@ -13,7 +13,7 @@
     ]
   },
   {
-    "name": "lemma - transcription: plus sign ('+') shouldn't be ignored",
+    "name": "transcription: plus sign ('+') shouldn't be ignored",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "1000+"
@@ -26,7 +26,7 @@
     ]
   },
   {
-    "name": "lemma - transcription: forward slash ('/') shouldn't be ignored",
+    "name": "transcription: forward slash ('/') shouldn't be ignored",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "1/2"
@@ -40,7 +40,7 @@
     ]
   },
   {
-    "name": "lemma - transcription: hyphen ('-') should not be used by tokenizer",
+    "name": "transcription: hyphen ('-') should not be used by tokenizer",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "zp-nfr"
@@ -54,7 +54,7 @@
     ]
   },
   {
-    "name": "lemma - transcription: hyphen ('-') should not be used by tokenizer, ḥm(.t)-ntr(.t) should be indexed correctly",
+    "name": "transcription: hyphen ('-') should not be used by tokenizer, ḥm(.t)-ntr(.t) should be indexed correctly",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "ḥm-ntr"
@@ -72,7 +72,7 @@
     ]
   },
   {
-    "name": "lemma - transcription: search for ḥm-nṯr should not find ḥm-ntr",
+    "name": "transcription: search for ḥm-nṯr should not find ḥm-ntr",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "ḥm-nṯr"
@@ -82,7 +82,7 @@
     ]
   },
   {
-    "name": "lemma - transcription: asterisk ('*') should not be ignored (find *ꜥpš)",
+    "name": "transcription: asterisk ('*') should not be ignored (find *ꜥpš)",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "*ꜥpš"
@@ -92,7 +92,7 @@
     ]
   },
   {
-    "name": "lemma - transcription: underscore ('_') should not be ignored",
+    "name": "transcription: underscore ('_') should not be ignored",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "_rw"
@@ -109,7 +109,7 @@
     ]
   },
   {
-    "name": "lemma - transcription: question marks ('⸮?') should be ignored",
+    "name": "transcription: question marks ('⸮?') should be ignored",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "Pa-⸮tꜣ?-gš"
@@ -126,7 +126,7 @@
     ]
   },
   {
-    "name": "lemma - transcription: asterisk ('*') should not be ignored (find *Pꜣ-ḏbꜣ)",
+    "name": "transcription: asterisk ('*') should not be ignored (find *Pꜣ-ḏbꜣ)",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "*Pꜣ-ḏbꜣ"

--- a/src/test/resources/search/lemma/transcription.json
+++ b/src/test/resources/search/lemma/transcription.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "transcription: parenthesis ('()') should be ignored",
+    "name": "parenthesis ('()') should be ignored",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "(j)bkꜥ"
@@ -13,7 +13,7 @@
     ]
   },
   {
-    "name": "transcription: plus sign ('+') shouldn't be ignored",
+    "name": "plus sign ('+') shouldn't be ignored",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "1000+"
@@ -26,7 +26,7 @@
     ]
   },
   {
-    "name": "transcription: forward slash ('/') shouldn't be ignored",
+    "name": "forward slash ('/') shouldn't be ignored",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "1/2"
@@ -40,7 +40,7 @@
     ]
   },
   {
-    "name": "transcription: hyphen ('-') should not be used by tokenizer",
+    "name": "hyphen ('-') should not be used by tokenizer",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "zp-nfr"
@@ -54,7 +54,7 @@
     ]
   },
   {
-    "name": "transcription: hyphen ('-') should not be used by tokenizer, ḥm(.t)-ntr(.t) should be indexed correctly",
+    "name": "hyphen ('-') should not be used by tokenizer, ḥm(.t)-ntr(.t) should be indexed correctly",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "ḥm-ntr"
@@ -72,7 +72,7 @@
     ]
   },
   {
-    "name": "transcription: search for ḥm-nṯr should not find ḥm-ntr",
+    "name": "search for ḥm-nṯr should not find ḥm-ntr",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "ḥm-nṯr"
@@ -82,7 +82,7 @@
     ]
   },
   {
-    "name": "transcription: asterisk ('*') should not be ignored (find *ꜥpš)",
+    "name": "asterisk ('*') should not be ignored (find *ꜥpš)",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "*ꜥpš"
@@ -92,7 +92,7 @@
     ]
   },
   {
-    "name": "transcription: underscore ('_') should not be ignored",
+    "name": "underscore ('_') should not be ignored",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "_rw"
@@ -109,7 +109,7 @@
     ]
   },
   {
-    "name": "transcription: question marks ('⸮?') should be ignored",
+    "name": "question marks ('⸮?') should be ignored",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "Pa-⸮tꜣ?-gš"
@@ -126,7 +126,7 @@
     ]
   },
   {
-    "name": "transcription: asterisk ('*') should not be ignored (find *Pꜣ-ḏbꜣ)",
+    "name": "asterisk ('*') should not be ignored (find *Pꜣ-ḏbꜣ)",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "*Pꜣ-ḏbꜣ"

--- a/src/test/resources/search/lemma/translation.json
+++ b/src/test/resources/search/lemma/translation.json
@@ -1,0 +1,71 @@
+[
+  {
+    "name": "german translation matches plural and genitive forms",
+    "cmd": {
+      "@class": "tla.domain.command.LemmaSearch",
+      "translation": {
+        "lang": [
+          "de"
+        ],
+        "text": "gott"
+      },
+      "sort": "sortKey_desc"
+    },
+    "valid": [
+      "177970",
+      "178400",
+      "178740",
+      "181000",
+      "182180",
+      "182700",
+      "183250",
+      "184030",
+      "185210",
+      "185970",
+      "185970",
+      "500591",
+      "500954",
+      "858969",
+      "859709",
+      "861900",
+      "d7746"
+    ],
+    "invalid": [
+      "d5417"
+    ]
+  },
+  {
+    "name": "german translation matches umlauts",
+    "cmd": {
+      "@class": "tla.domain.command.LemmaSearch",
+      "translation": {
+        "lang": [
+          "de"
+        ],
+        "text": "koenig"
+      },
+      "script": ["demotic"]
+    },
+    "valid": [
+      "dm2169",
+      "d3265",
+      "d3260",
+      "d444"
+    ]
+  },
+  {
+    "name": "french translation matches accents",
+    "cmd": {
+      "@class": "tla.domain.command.LemmaSearch",
+      "translation": {
+        "lang": [
+          "fr"
+        ],
+        "text": "divinite"
+      }
+    },
+    "valid": [
+      "90260"
+    ]
+  }
+]

--- a/src/test/resources/search/sentence/tokens.json
+++ b/src/test/resources/search/sentence/tokens.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "nested query for multiple token translations",
+    "cmd": {
+      "@class": "tla.domain.command.SentenceSearch",
+      "tokens": [
+        {
+          "translation": {
+            "text": "pferd",
+            "lang": [
+              "de"
+            ]
+          }
+        },
+        {
+          "translation": {
+            "text": "besteigen",
+            "lang": [
+              "de"
+            ]
+          }
+        }
+      ]
+    },
+    "valid": [
+      "IBUBd6ylgyTRukptsjCV3yjpYJc",
+      "IBUBd28QjXhBQ0CjvCf7MDceWz0",
+      "IBUBd0s5MwtBHkQWnTS4E09vjLU",
+      "IBUBd0VEZ2OE3k2mhPtBuNSpGkU"
+    ]
+  }
+]

--- a/src/test/resources/search/tests.json
+++ b/src/test/resources/search/tests.json
@@ -82,13 +82,63 @@
     ]
   },
   {
-    "name": "lemma - transcription: asterisk ('*') should not be ignored",
+    "name": "lemma - transcription: asterisk ('*') should not be ignored (find *ꜥpš)",
     "cmd": {
       "@class": "tla.domain.command.LemmaSearch",
       "transcription": "*ꜥpš"
     },
     "valid": [
       "dm4619"
+    ]
+  },
+  {
+    "name": "lemma - transcription: underscore ('_') should not be ignored",
+    "cmd": {
+      "@class": "tla.domain.command.LemmaSearch",
+      "transcription": "_rw"
+    },
+    "valid": [
+      "dm4228"
+    ],
+    "invalid": [
+      "dm5769",
+      "d3454",
+      "500396",
+      "860603",
+      "871109"
+    ]
+  },
+  {
+    "name": "lemma - transcription: question marks ('⸮?') should be ignored",
+    "cmd": {
+      "@class": "tla.domain.command.LemmaSearch",
+      "transcription": "Pa-⸮tꜣ?-gš"
+    },
+    "valid": [
+      "dm5732"
+    ],
+    "invalid": [
+      "dm2818",
+      "dm2550",
+      "dm2551",
+      "858492",
+      "d1931"
+    ]
+  },
+  {
+    "name": "lemma - transcription: asterisk ('*') should not be ignored (find *Pꜣ-ḏbꜣ)",
+    "cmd": {
+      "@class": "tla.domain.command.LemmaSearch",
+      "transcription": "*Pꜣ-ḏbꜣ"
+    },
+    "valid": [
+      "dm1651"
+    ],
+    "invalid": [
+      "851446",
+      "d7182",
+      "183280",
+      "dm4617"
     ]
   }
 ]

--- a/src/test/resources/search/tests.json
+++ b/src/test/resources/search/tests.json
@@ -1,0 +1,84 @@
+[
+  {
+    "name": "lemma - transcription: parenthesis ('()') should be ignored",
+    "cmd": {
+      "@class": "tla.domain.command.LemmaSearch",
+      "transcription": "(j)bkꜥ"
+    },
+    "valid": [
+      "709902"
+    ],
+    "invalid": [
+      "500024"
+    ]
+  },
+  {
+    "name": "lemma - transcription: plus sign ('+') shouldn't be ignored",
+    "cmd": {
+      "@class": "tla.domain.command.LemmaSearch",
+      "transcription": "1000+"
+    },
+    "valid": [
+      "dm5964"
+    ],
+    "invalid": [
+      "dm879"
+    ]
+  },
+  {
+    "name": "lemma - transcription: forward slash ('/') shouldn't be ignored",
+    "cmd": {
+      "@class": "tla.domain.command.LemmaSearch",
+      "transcription": "1/2"
+    },
+    "valid": [
+      "99026"
+    ],
+    "invalid": [
+      "600014",
+      "600017"
+    ]
+  },
+  {
+    "name": "lemma - transcription: hyphen ('-') should not be used by tokenizer",
+    "cmd": {
+      "@class": "tla.domain.command.LemmaSearch",
+      "transcription": "zp-nfr"
+    },
+    "valid": [
+      "132560"
+    ],
+    "invalid": [
+      "136212",
+      "859569"
+    ]
+  },
+  {
+    "name": "lemma - transcription: hyphen ('-') should not be used by tokenizer, ḥm(.t)-ntr(.t) should be indexed correctly",
+    "cmd": {
+      "@class": "tla.domain.command.LemmaSearch",
+      "transcription": "ḥm-ntr"
+    },
+    "valid": [
+      "d4073"
+    ],
+    "invalid": [
+      "98390",
+      "869552",
+      "dm2190",
+      "98380",
+      "500881"
+    ]
+  },
+  {
+    "name": "lemma - transcription: asterisk ('*') should not be ignored",
+    "cmd": {
+      "@class": "tla.domain.command.LemmaSearch",
+      "transcription": "*ꜥpš"
+    },
+    "valid": [
+      "dm4619"
+    ]
+  }
+]
+

--- a/src/test/resources/search/tests.json
+++ b/src/test/resources/search/tests.json
@@ -63,11 +63,22 @@
       "d4073"
     ],
     "invalid": [
+      "855724",
       "98390",
       "869552",
       "dm2190",
       "98380",
       "500881"
+    ]
+  },
+  {
+    "name": "lemma - transcription: search for ḥm-nṯr should not find ḥm-ntr",
+    "cmd": {
+      "@class": "tla.domain.command.LemmaSearch",
+      "transcription": "ḥm-nṯr"
+    },
+    "invalid": [
+      "d4073"
     ]
   },
   {


### PR DESCRIPTION
Observations like https://github.com/thesaurus-linguae-aegyptiae/tla-web/issues/90, https://github.com/thesaurus-linguae-aegyptiae/tla-web/issues/89, https://github.com/thesaurus-linguae-aegyptiae/tla-web/issues/87, or https://github.com/thesaurus-linguae-aegyptiae/tla-web/issues/54 make it very clear that an integrated system for formalized validation of actual search requests is due. To facilitate this, a generic integration test case is being parameterized with search commands read from data files, and the results of their execution against a populated Elasticsearch instance are compared with basic expectations defined alongside them. The newly introduced application property `tla.searchtest.path` can be used to configure a classpath reosource directory to be scanned for JSON files containing such test cases (currently `src/test/resources/search/{objectType}/`). Test cases consist of a search command and the IDs of both valid and false positive search results.

Search tests based on this system (which require `./gradlew populate` with sample data) can be run separately from unittests with the Gradle task `:testSearch`, or in conjunction with them with task `:testAll`.

fixes https://github.com/thesaurus-linguae-aegyptiae/tla-web/issues/89  
fixes https://github.com/thesaurus-linguae-aegyptiae/tla-web/issues/90