### PR TITLE
Nest time period lemma attestations into logical structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.0.1-jdk11 AS build
+FROM gradle:7.0.2-jdk11 AS build
 
 COPY --chown=gradle:gradle . /home/gradle/tla
 WORKDIR /home/gradle/tla

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.0.0-jdk11 AS build
+FROM gradle:7.0.1-jdk11 AS build
 
 COPY --chown=gradle:gradle . /home/gradle/tla
 WORKDIR /home/gradle/tla

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ The paths used to identify the entity services can be found in the `@ModelClass`
 
 Test runs create JUnit and Jacoco reports at the usual output locations.
 
+Limit test runs to single classes by using the `--test` option:
+
+```bash
+  ./gradlew test --tests=QueryResultTest
+```
+
 
 ## Misc
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![build](https://github.com/jkatzwinkel/tla-es/workflows/build/badge.svg)
 ![deploy](https://github.com/jkatzwinkel/tla-es/workflows/deploy/badge.svg)
 ![search](https://github.com/jkatzwinkel/tla-es/workflows/searchtest/badge.svg)
-![LINE](https://img.shields.io/badge/line--coverage-73%25-yellow.svg)
-![METHOD](https://img.shields.io/badge/method--coverage-77%25-yellow.svg)
+![LINE](https://img.shields.io/badge/line--coverage-76%25-yellow.svg)
+![METHOD](https://img.shields.io/badge/method--coverage-78%25-yellow.svg)
 
 # tla-es
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![build](https://github.com/jkatzwinkel/tla-es/workflows/build/badge.svg)
 ![deploy](https://github.com/jkatzwinkel/tla-es/workflows/deploy/badge.svg)
 ![search](https://github.com/jkatzwinkel/tla-es/workflows/searchtest/badge.svg)
-![LINE](https://img.shields.io/badge/line--coverage-68%25-yellow.svg)
-![METHOD](https://img.shields.io/badge/method--coverage-75%25-yellow.svg)
+![LINE](https://img.shields.io/badge/line--coverage-73%25-yellow.svg)
+![METHOD](https://img.shields.io/badge/method--coverage-77%25-yellow.svg)
 
 # tla-es
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'org.bbaw.aaew.tla'
-version = '0.0.834'
+version = '0.0.835'
 sourceCompatibility = '11'
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -54,20 +54,20 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.20'
 
     implementation 'com.github.jkatzwinkel:tla-common:query-expansion-SNAPSHOT'
-    implementation 'org.modelmapper:modelmapper:2.4.1'
+    implementation 'org.modelmapper:modelmapper:2.4.3'
     implementation 'org.apache.commons:commons-compress:1.20'
     implementation 'org.apache.tomcat.embed:tomcat-embed-core:9.0.35'
     implementation 'org.yaml:snakeyaml:1.28'
 
-    implementation 'org.springframework.boot:spring-boot:2.5.0-M1'
-    implementation 'org.springframework.boot:spring-boot-autoconfigure:2.5.0-M1'
+    implementation 'org.springframework.boot:spring-boot:2.5.0-RC1'
+    implementation 'org.springframework.boot:spring-boot-autoconfigure:2.5.0-RC1'
     implementation 'org.springframework.data:spring-data-elasticsearch:4.2.0-M1'
-    implementation 'org.springframework:spring-web:5.3.6'
-    implementation 'org.springframework:spring-webmvc:5.3.6'
+    implementation 'org.springframework:spring-web:5.3.7'
+    implementation 'org.springframework:spring-webmvc:5.3.7'
     implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
     implementation 'org.slf4j:slf4j-simple:2.0.0-alpha1'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.5.0-M3'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.5.0-RC1'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.0-M1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.0-M1'
 }
@@ -96,7 +96,7 @@ task testSearch(type: Test) {
 
 task testAll(type: Test) {
     group = 'Verification'
-		description = 'Runs both search integration and unit tests.'
+    description = 'Runs both search integration and unit tests.'
     useJUnitPlatform()
     environment "ES_PORT", env.fetch("ES_PORT", "9200")
     finalizedBy 'jacocoTestReport'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = 'org.bbaw.aaew.tla'
-version = '0.0.833'
+version = '0.0.834'
 sourceCompatibility = '11'
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -6,19 +6,19 @@ plugins {
     id 'maven-publish'
     id 'co.uzzu.dotenv.gradle' version '1.1.0'
     id 'de.undercouch.download' version '4.1.1'
-    id 'org.springframework.boot' version '2.4.5'
+    id 'org.springframework.boot' version '2.5.0'
     id 'com.github.ben-manes.versions' version '0.38.0'
     id 'com.github.dawnwords.jacoco.badge' version '0.2.0'
 }
 
 group = 'org.bbaw.aaew.tla'
-version = '0.0.835'
+version = '0.0.840'
 sourceCompatibility = '11'
 
 publishing {
     publications {
         maven(MavenPublication) {
-            artifactId = 'tla-elasticsearch'
+            artifactId = 'tla-es'
             pom {
                 name = 'TLA Elasticsearch Backend'
                 description = 'Elasticsearch backend for the Thesaurus Linguae Aegyptiae web component'
@@ -53,21 +53,21 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.20'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.20'
 
-    implementation 'com.github.jkatzwinkel:tla-common:query-expansion-SNAPSHOT'
+    implementation 'com.github.jkatzwinkel:tla-common:master-SNAPSHOT'
     implementation 'org.modelmapper:modelmapper:2.4.3'
     implementation 'org.apache.commons:commons-compress:1.20'
     implementation 'org.apache.tomcat.embed:tomcat-embed-core:9.0.35'
     implementation 'org.yaml:snakeyaml:1.28'
 
-    implementation 'org.springframework.boot:spring-boot:2.5.0-RC1'
-    implementation 'org.springframework.boot:spring-boot-autoconfigure:2.5.0-RC1'
+    implementation 'org.springframework.boot:spring-boot:2.5.0'
+    implementation 'org.springframework.boot:spring-boot-autoconfigure:2.5.0'
     implementation 'org.springframework.data:spring-data-elasticsearch:4.2.0-M1'
     implementation 'org.springframework:spring-web:5.3.7'
     implementation 'org.springframework:spring-webmvc:5.3.7'
     implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
     implementation 'org.slf4j:slf4j-simple:2.0.0-alpha1'
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.5.0-RC1'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:2.5.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.0-M1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.0-M1'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/tla/backend/es/model/LemmaEntity.java
+++ b/src/main/java/tla/backend/es/model/LemmaEntity.java
@@ -63,7 +63,6 @@ public class LemmaEntity extends TLAEntity {
 
     @Getter
     @Setter
-    @EqualsAndHashCode
     @NoArgsConstructor
     @AllArgsConstructor
     @JsonInclude(Include.NON_NULL)

--- a/src/main/java/tla/backend/es/model/TextEntity.java
+++ b/src/main/java/tla/backend/es/model/TextEntity.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+import tla.backend.es.model.meta.Recursable;
 import tla.backend.es.model.meta.UserFriendlyEntity;
 import tla.backend.es.model.parts.ObjectPath;
 import tla.backend.es.model.parts.Translations;
@@ -27,7 +28,7 @@ import tla.domain.model.meta.TLADTO;
 @BTSeClass("BTSText")
 @TLADTO(TextDto.class)
 @Document(indexName = "text")
-public class TextEntity extends UserFriendlyEntity {
+public class TextEntity extends UserFriendlyEntity implements Recursable {
 
     @Field(type = FieldType.Search_As_You_Type, name = "hash")
     private String SUID;

--- a/src/main/java/tla/backend/es/model/ThsEntryEntity.java
+++ b/src/main/java/tla/backend/es/model/ThsEntryEntity.java
@@ -152,7 +152,7 @@ public class ThsEntryEntity extends UserFriendlyEntity implements Recursable {
         return AttestedTimespan.Period.builder()
             .begin(years.get(0))
             .end(years.get(1))
-            .ths(this.toDTOReference())
+            .ref(this.toDTOReference())
             .build();
     }
 }

--- a/src/main/java/tla/backend/es/model/ThsEntryEntity.java
+++ b/src/main/java/tla/backend/es/model/ThsEntryEntity.java
@@ -20,6 +20,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
+import tla.backend.es.model.meta.Recursable;
 import tla.backend.es.model.meta.UserFriendlyEntity;
 import tla.backend.es.model.parts.ObjectPath;
 import tla.backend.es.model.parts.Translations;
@@ -38,7 +39,7 @@ import tla.domain.model.meta.TLADTO;
 @EqualsAndHashCode(callSuper = true)
 @Document(indexName = "ths")
 @Setting(settingPath = "/elasticsearch/settings/indices/ths.json")
-public class ThsEntryEntity extends UserFriendlyEntity {
+public class ThsEntryEntity extends UserFriendlyEntity implements Recursable {
 
     private static ObjectMapper objectMapper = tla.domain.util.IO.getMapper();
 

--- a/src/main/java/tla/backend/es/model/Util.java
+++ b/src/main/java/tla/backend/es/model/Util.java
@@ -3,7 +3,6 @@ package tla.backend.es.model;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/tla/backend/es/model/Util.java
+++ b/src/main/java/tla/backend/es/model/Util.java
@@ -1,5 +1,10 @@
 package tla.backend.es.model;
 
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Stream;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -37,5 +42,14 @@ public class Util {
             return entity.getId();
         }
     }
-    
+
+    /**
+     * return list elements in inverse order.
+     */
+    public static <E> List<E> reverse(List<E> list) {
+        var tmp = new LinkedList<>(list);
+        Collections.reverse(tmp);
+        return tmp;
+    }
+
 }

--- a/src/main/java/tla/backend/es/model/meta/BaseEntity.java
+++ b/src/main/java/tla/backend/es/model/meta/BaseEntity.java
@@ -8,6 +8,7 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.experimental.SuperBuilder;
 import tla.backend.es.model.parts.EditorInfo;
@@ -31,6 +32,7 @@ import tla.domain.model.meta.TLADTO;
  */
 @Data
 @SuperBuilder
+@NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @EqualsAndHashCode(callSuper = true)
 public abstract class BaseEntity extends LinkedEntity implements Indexable {
@@ -58,13 +60,6 @@ public abstract class BaseEntity extends LinkedEntity implements Indexable {
      */
     @Field(type = FieldType.Object)
     private EditorInfo editors;
-
-    /**
-     * Default constructor initializing the relations map as an empty object.
-     */
-    public BaseEntity() {
-
-    }
 
     /**
      * Converts an instance to a DTO of the type specified via {@link TLADTO} annotation

--- a/src/main/java/tla/backend/es/model/meta/LinkedEntity.java
+++ b/src/main/java/tla/backend/es/model/meta/LinkedEntity.java
@@ -20,6 +20,7 @@ import lombok.Singular;
 import lombok.experimental.SuperBuilder;
 import tla.backend.es.model.parts.ObjectReference;
 import tla.domain.model.meta.AbstractBTSBaseClass;
+import tla.domain.model.meta.Relatable;
 import tla.domain.model.meta.Resolvable;
 
 @Getter
@@ -27,22 +28,7 @@ import tla.domain.model.meta.Resolvable;
 @SuperBuilder
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @EqualsAndHashCode(callSuper = true, exclude = {"relations"})
-public abstract class LinkedEntity extends AbstractBTSBaseClass {
-
-    /**
-     * References to related objects grouped by relationship name (<code>partOf</code>,
-     * <code>predecessor</code>, ...).
-     */
-    @Singular
-    @Field(type = FieldType.Object)
-    private Map<String, Relations> relations;
-
-    /**
-     * Default constructor initializing the relations map as an empty object.
-     */
-    public LinkedEntity() {
-        this.relations = Collections.emptyMap();
-    }
+public abstract class LinkedEntity extends AbstractBTSBaseClass implements Relatable<LinkedEntity.Relations> {
 
     /**
      * A collection of references to other entity objects.
@@ -64,6 +50,21 @@ public abstract class LinkedEntity extends AbstractBTSBaseClass {
                 Arrays.asList(sources)
             );
         }
+    }
+
+    /**
+     * References to related objects grouped by relationship name (<code>partOf</code>,
+     * <code>predecessor</code>, ...).
+     */
+    @Singular
+    @Field(type = FieldType.Object)
+    private Map<String, Relations> relations;
+
+    /**
+     * Default constructor initializing the relations map as an empty object.
+     */
+    public LinkedEntity() {
+        this.relations = Collections.emptyMap();
     }
 
 }

--- a/src/main/java/tla/backend/es/model/meta/Recursable.java
+++ b/src/main/java/tla/backend/es/model/meta/Recursable.java
@@ -1,0 +1,39 @@
+package tla.backend.es.model.meta;
+
+import tla.backend.es.model.parts.ObjectPath;
+import tla.domain.model.meta.Resolvable;
+
+public interface Recursable {
+
+    /**
+     * get paths whose traversal through the object tree lead to this entity.
+     */
+    public ObjectPath[] getPaths();
+
+    public void setPaths(ObjectPath[] paths);
+
+    /**
+     * determine whether another object is living in this entity's sub tree.
+     */
+    default public boolean isAncestorOf(Recursable entity) {
+        if (entity.getPaths() != null) {
+            Resolvable ref = ((BaseEntity) this).toDTOReference();
+            for (ObjectPath path : entity.getPaths()) {
+                if (path.stream().anyMatch(
+                    segment -> segment.getId().equals(ref.getId())
+                )) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * determine whether another object is an ancestral node of this entity.
+     */
+    default public boolean hasAncestor(Recursable entity) {
+        return entity.isAncestorOf(this);
+    }
+
+}

--- a/src/main/java/tla/backend/es/query/ESQueryResult.java
+++ b/src/main/java/tla/backend/es/query/ESQueryResult.java
@@ -11,8 +11,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.SearchHits;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 import tla.backend.es.model.meta.Indexable;
 import tla.domain.dto.extern.PageInfo;
 
@@ -76,6 +74,9 @@ public class ESQueryResult<T extends Indexable> {
         return Collections.emptyMap();
     }
 
+    /**
+     * save terms aggregation results.
+     */
     public void addAggregations(Map<String, Map<String, Long>> aggs) {
         this.aggregations.putAll(aggs);
     }

--- a/src/main/java/tla/backend/es/query/ESQueryResult.java
+++ b/src/main/java/tla/backend/es/query/ESQueryResult.java
@@ -69,7 +69,9 @@ public class ESQueryResult<T extends Indexable> {
                     hits.getSearchHits().size()
                 )
             ).totalPages(
-                (int) hits.getTotalHits() / SEARCH_RESULT_PAGE_SIZE + 1 // TODO
+                (int) hits.getTotalHits() / SEARCH_RESULT_PAGE_SIZE + (
+                    hits.getTotalHits() % SEARCH_RESULT_PAGE_SIZE < 1 ? 0 : 1
+                )
             ).build();
     }
 

--- a/src/main/java/tla/backend/es/query/ESQueryResult.java
+++ b/src/main/java/tla/backend/es/query/ESQueryResult.java
@@ -1,6 +1,9 @@
 package tla.backend.es.query;
 
-import java.util.List;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -19,8 +22,6 @@ import tla.domain.dto.extern.PageInfo;
  * <code>&lt;T&gt;</code>: an {@link Indexable} entity class
  */
 @Getter
-@Setter
-@NoArgsConstructor
 public class ESQueryResult<T extends Indexable> {
 
     /**
@@ -28,30 +29,55 @@ public class ESQueryResult<T extends Indexable> {
      */
     public static final int SEARCH_RESULT_PAGE_SIZE = 20;
 
+    /**
+     * IDs aggregation identifier
+     */
+    public static final String AGGS_ID_IDS = "ids";
+
+    private Map<String, Map<String, Long>> aggregations;
+
     private SearchHits<T> hits;
 
     private PageInfo pageInfo;
 
+    public ESQueryResult() {
+        this.aggregations = new HashMap<>();
+    }
+
     public ESQueryResult(SearchHits<T> hits, Pageable page) {
+        this();
         this.hits = hits;
         this.pageInfo = page.isUnpaged() ? null : pageInfo(hits, page);
     }
 
     /**
      * if there is an IDs aggregation, extract IDs from it.
-     * @return
      */
-    public List<String> getIDAggValues() {
-        if (this.hits.getAggregations() != null && this.hits.getAggregations().get("ids") != null) {
+    public Collection<String> getIDAggValues() {
+        return this.getAggregation(AGGS_ID_IDS).keySet();
+    }
+
+    /**
+     * extract a terms aggregation of the specified name.
+     *
+     * @return map of aggregated terms and corresponding document counts, or an empty map if the
+     * aggregation doesn't exist
+     */
+    public Map<String, Long> getAggregation(String agg) {
+        if (this.hits.getAggregations() != null && this.hits.getAggregations().get(agg) != null) {
             return (
-                (Terms) this.hits.getAggregations().get("ids")
-            ).getBuckets().stream().map(
-                Terms.Bucket::getKeyAsString
-            ).collect(
-                Collectors.toList()
+                (Terms) this.hits.getAggregations().get(agg)
+            ).getBuckets().stream().collect(
+                Collectors.toMap(
+                    Terms.Bucket::getKeyAsString, Terms.Bucket::getDocCount
+                )
             );
         }
-        return null;
+        return Collections.emptyMap();
+    }
+
+    public void addAggregations(Map<String, Map<String, Long>> aggs) {
+        this.aggregations.putAll(aggs);
     }
 
     /**

--- a/src/main/java/tla/backend/es/query/ExpansionQueryBuilder.java
+++ b/src/main/java/tla/backend/es/query/ExpansionQueryBuilder.java
@@ -6,6 +6,9 @@ import org.elasticsearch.search.aggregations.BucketOrder;
 
 public interface ExpansionQueryBuilder extends TLAQueryBuilder {
 
+    final static String ID_FIELD = "id";
+    final static int ID_AGG_SIZE = 1000000;
+
     /**
      * If set to true, query is considered an expansion query, meaning that no paged results
      * are being fetched, and an ID aggregation is added instead.
@@ -13,7 +16,11 @@ public interface ExpansionQueryBuilder extends TLAQueryBuilder {
     public default void setExpansion(boolean expansion) {
         if (expansion) {
             this.aggregate(
-                AggregationBuilders.terms("ids").field("id").size(100000).order(BucketOrder.key(true))
+                AggregationBuilders.terms(
+                    ESQueryResult.AGGS_ID_IDS
+                ).field(ID_FIELD).size(ID_AGG_SIZE).order(
+                    BucketOrder.key(true)
+                )
             );
         }
     }

--- a/src/main/java/tla/backend/es/query/OccurrenceSearchQueryBuilder.java
+++ b/src/main/java/tla/backend/es/query/OccurrenceSearchQueryBuilder.java
@@ -1,0 +1,73 @@
+package tla.backend.es.query;
+
+import java.util.List;
+
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.BucketOrder;
+
+import tla.backend.es.model.TextEntity;
+import tla.backend.service.ModelClass;
+import tla.domain.model.SentenceToken.Lemmatization;
+
+/**
+ * look up lemma occurrences. Lemma occurrence counts per text are gonna be in
+ * the result's {@link #AGG_ID_TEXT_IDS} aggregation.
+ *
+ * @see ESQueryResult#getAggregation(String)
+ */
+@ModelClass(TextEntity.class)
+public class OccurrenceSearchQueryBuilder extends TextSearchQueryBuilder {
+
+    final static String AGG_ID_TEXT_IDS = "text_ids";
+
+    /**
+     * instantiates a query builder for searching lemma attestations, which is
+     * basically a text search query builder fed by a sentence query builder
+     * dependency with a text IDs aggregation and a nested token query looking
+     * for the specified lemma.
+     */
+    public OccurrenceSearchQueryBuilder(String lemmaId) {
+        super();
+        SentenceSearchQueryBuilder sentenceQuery = sentenceQuery(lemmaId);
+        this.dependsOn(
+            sentenceQuery,
+            this::setId,
+            sentenceDependency -> sentenceDependency.getResult().getAggregation(
+                AGG_ID_TEXT_IDS
+            ).keySet().toArray(new String[]{})
+        );
+    }
+
+    /**
+     * create builder for nested query matching sentence tokens lemmatized with
+     * specified lemma ID.
+     */
+    static TokenSearchQueryBuilder occurrenceTokenQuery(String lemmaId) {
+        var tokenQuery = new TokenSearchQueryBuilder();
+        tokenQuery.setLemma(
+            new Lemmatization(lemmaId, null)
+        );
+        return tokenQuery;
+    }
+
+    /**
+     * create sentence query builder matching sentences containing specified lemma,
+     * aggregating IDs of containing text entities in a terms aggregation named
+     * {@link #AGG_ID_TEXT_IDS}.
+     */
+    static SentenceSearchQueryBuilder sentenceQuery(String lemmaId) {
+        var query = new SentenceSearchQueryBuilder();
+        query.setTokens(List.of(occurrenceTokenQuery(lemmaId)));
+        query.aggregate(
+            AggregationBuilders.terms(AGG_ID_TEXT_IDS).field(
+                "context.textId"
+            ).order(
+                BucketOrder.key(true)
+            ).size(
+                ExpansionQueryBuilder.ID_AGG_SIZE
+            )
+        );
+        return query;
+    }
+
+}

--- a/src/main/java/tla/backend/es/query/PassportIncludingQueryBuilder.java
+++ b/src/main/java/tla/backend/es/query/PassportIncludingQueryBuilder.java
@@ -5,6 +5,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import tla.domain.command.PassportSpec;
+import tla.domain.command.PassportSpec.PassportSpecValue;
 
 @Slf4j
 @Getter
@@ -12,6 +13,12 @@ public class PassportIncludingQueryBuilder extends ESQueryBuilder {
 
     private PassportSpec passport = new PassportSpec();
 
+    /**
+     * Register a new {@link ThsRefExpansionDependency} query dependency for thesaurus entry ID
+     * query expansion if the passport property search specification's expansion flag is set,
+     * or register an ES terms query filter matching a (potentially already expanded) list of
+     * thesaurus entry IDs.
+     */
     private void processThsReferences(String key, PassportSpec.ThsRefPassportValue values) {
         if (values.isExpand()) {
             this.dependsOn(
@@ -30,24 +37,37 @@ public class PassportIncludingQueryBuilder extends ESQueryBuilder {
         }
     }
 
+    /**
+     * Register a conjunct ES match query if an individual passport property search specification
+     * contains literal values, or consider it for query expansion otherwise (i.e. if it
+     * specified thesaurus entries).
+     *
+     * @see #processThsReferences(String, tla.domain.command.PassportSpec.ThsRefPassportValue)
+     */
+    private void processPassportProperty(String key, PassportSpecValue value) {
+        if (!value.getValues().isEmpty()) {
+            if (value instanceof PassportSpec.ThsRefPassportValue) {
+                processThsReferences(key, (PassportSpec.ThsRefPassportValue) value);
+            } else {
+                this.must(
+                    QueryBuilders.matchQuery(
+                        String.format("passport.%s", key),
+                        String.join(" ", value.getValues())
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * Add passport search specifications to this query builder, possibly queuing additional
+     * query dependencies for thesaurus reference query expansion.
+     */
     public void setPassport(PassportSpec spec) {
         if (spec != null && !spec.isEmpty()) {
             log.info("passport specs: {}", tla.domain.util.IO.json(spec));
-            spec.entrySet().forEach(
-                e -> {
-                    if (!e.getValue().getValues().isEmpty()) {
-                        if (e.getValue() instanceof PassportSpec.ThsRefPassportValue) {
-                            processThsReferences(e.getKey(), (PassportSpec.ThsRefPassportValue) e.getValue());
-                        } else {
-                            this.must(
-                                QueryBuilders.matchQuery(
-                                    String.format("passport.%s", e.getKey()),
-                                    String.join(" ", e.getValue().getValues())
-                                )
-                            );
-                        }
-                    }
-                }
+            spec.forEach(
+                this::processPassportProperty
             );
         }
     }

--- a/src/main/java/tla/backend/es/query/SentenceSearchQueryBuilder.java
+++ b/src/main/java/tla/backend/es/query/SentenceSearchQueryBuilder.java
@@ -44,8 +44,7 @@ public class SentenceSearchQueryBuilder extends ESQueryBuilder implements MultiL
             textSearchQuery.setPassport(spec);
             this.dependsOn(
                 textSearchQuery,
-                this::setTextIds,
-                query -> query.getResult().getIDAggValues()
+                this::setTextIds
             );
         }
     }

--- a/src/main/java/tla/backend/es/query/TLAQueryBuilder.java
+++ b/src/main/java/tla/backend/es/query/TLAQueryBuilder.java
@@ -1,6 +1,7 @@
 package tla.backend.es.query;
 
 import java.lang.annotation.Annotation;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -78,6 +79,7 @@ public interface TLAQueryBuilder {
     }
 
     public List<QueryDependency<?>> getDependencies();
+
     /**
      * Resolve dependencies and return list of native query builders in a sequence 
      */

--- a/src/main/java/tla/backend/es/query/TLAQueryBuilder.java
+++ b/src/main/java/tla/backend/es/query/TLAQueryBuilder.java
@@ -12,7 +12,6 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import tla.backend.es.model.meta.Indexable;
 import tla.backend.service.ModelClass;
@@ -22,31 +21,38 @@ import tla.backend.service.ModelClass;
  */
 public interface TLAQueryBuilder {
 
+    /**
+     * Represents a dependency relationship to a search query builder, consisting of the query builder
+     * instance, a method belonging to the dependent query builder waiting for results, and a functional
+     * producer generating the input for the waiting method, i.e. some function returning results from
+     * the prerequisite query's {@link ESQueryResult} from {@link TLAQueryBuilder#getResult()}.
+     */
     @Slf4j
-    @Getter
-    @Setter
     public static class QueryDependency<D> {
+
         /**
          * query that must run first
          */
+        @Getter
         private TLAQueryBuilder query;
+
         /**
          * method waiting for query execution result
          */
         private Consumer<D> dependentMethod;
+
         /**
          * dependency's method providing us with the result we need
          */
         private Function<TLAQueryBuilder, D> inputMethod;
-        /**
-         * 
-         */
+
         public QueryDependency(TLAQueryBuilder query, Consumer<D> blockedMethod, Function<TLAQueryBuilder, D> blockingMethod) {
             log.info("{}: adding dependency on method {} in query adapter {}", this, blockingMethod, query);
             this.query = query;
             this.dependentMethod = blockedMethod;
             this.inputMethod = blockingMethod;
         }
+
         /**
          * invoke inputMethod on query dependency and feed the return value into the
          * dependent method of the owning query.
@@ -57,17 +63,37 @@ public interface TLAQueryBuilder {
             log.info("Feed return value {} into blocked method {}..", input, this.dependentMethod);
             this.dependentMethod.accept(input);
         }
+
     }
 
     /**
-     * Adds another native search query builder instance the results of which
-     * are to be used in this native search query builder's query execution, and which
-     * must therefor run first, to the dependency queue.
+     * Adds another native search query builder instance to this builder's dependency list.
+     * Dependencies are executed first, and a producer function feeds the result of their execution
+     * into a consumer method belonging to this builder instance.
+     *
+     * @param query the search query builder to depend on
+     * @param blockedMethod consumer method waiting for query execution results
+     * @param blockingMethod producer function feeding input into the consumer
      */
     public default <D> TLAQueryBuilder dependsOn(
         TLAQueryBuilder query, Consumer<D> blockedMethod, Function<TLAQueryBuilder, D> blockingMethod
     ) {
         return this.dependsOn(new QueryDependency<D>(query, blockedMethod, blockingMethod));
+    }
+
+    /**
+     * Adds a dependency to the IDs aggregation of an expansion query.
+     *
+     * @param query search query builder on which we wait to be executed
+     * @param blockedMethod method of the dependent query waiting to consume the execution result's IDs aggregation values
+     * @see #dependsOn(TLAQueryBuilder, Consumer, Function)
+     */
+    public default TLAQueryBuilder dependsOn(
+        ExpansionQueryBuilder query, Consumer<Collection<String>> blockedMethod
+    ) {
+        return this.dependsOn(
+            query, blockedMethod, dep -> dep.getResult().getIDAggValues()
+        );
     }
 
     /**

--- a/src/main/java/tla/backend/es/query/TextSearchQueryBuilder.java
+++ b/src/main/java/tla/backend/es/query/TextSearchQueryBuilder.java
@@ -1,5 +1,8 @@
 package tla.backend.es.query;
 
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.BucketOrder;
+
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import tla.backend.es.model.TextEntity;
@@ -10,9 +13,21 @@ import tla.backend.service.ModelClass;
 @ModelClass(TextEntity.class)
 public class TextSearchQueryBuilder extends PassportIncludingQueryBuilder implements ExpansionQueryBuilder {
 
+    public static final String AGG_ID_DATE = "passport.date.date.date";
+
     private boolean expansion;
 
     private String[] rootIds;
+
+    public TextSearchQueryBuilder() {
+        this.aggregate(
+            AggregationBuilders.terms(AGG_ID_DATE).field(
+                String.format("%s.id.keyword", AGG_ID_DATE)
+            ).size(1000).order(
+                BucketOrder.key(true)
+            )
+        );
+    }
 
     @Override
     public void setExpansion(boolean expansion) {

--- a/src/main/java/tla/backend/es/query/ThsRefExpansionDependency.java
+++ b/src/main/java/tla/backend/es/query/ThsRefExpansionDependency.java
@@ -18,6 +18,17 @@ public class ThsRefExpansionDependency extends TLAQueryBuilder.QueryDependency<P
         super(query, blockedMethod, blockingMethod);
     }
 
+    /**
+     * Queue a new query builder for retrieval of the IDs of all thesaurus entries descending from
+     * those specified.
+     *
+     * This adds a new expansion-mode {@link ThsSearchQueryBuilder} to the dependency list of the waiting
+     * {@link PassportIncludingQueryBuilder}. This dependency will retrieve the IDs of all thesaurus
+     * entries descending of any of the thesaurus entries specified (i.e. who are located within the
+     * subtrees under the specified thesaurus entries). The results are fed into the waiting query builder's
+     * {@link PassportIncludingQueryBuilder#setPassport(PassportSpec)} method.
+     *
+     */
     public static ThsRefExpansionDependency of(
         PassportIncludingQueryBuilder waitingQuery,
         String passportKey,

--- a/src/main/java/tla/backend/es/query/package-info.java
+++ b/src/main/java/tla/backend/es/query/package-info.java
@@ -10,6 +10,9 @@
  * Furthermore, there is a kinda clumsy abstraction for query dependency tree execution which to at
  * least some degree is capable of emulating JOIN queries.
  *
+ * @see tla.backend.es.query.ESQueryBuilder
+ * @see tla.backend.es.query.ESQueryResult
+ *
  * @author jhoeper
  */
 package tla.backend.es.query;

--- a/src/main/java/tla/backend/es/query/package-info.java
+++ b/src/main/java/tla/backend/es/query/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * This package contains query mapping and expansion logic and abstraction.
+ *
+ * The idea is that incoming {@link tla.domain.command.SearchCommand} objects sent by a client (like the frontend)
+ * are automatically mapped to corresponding query builder objects according to mappings defined
+ * in {@link tla.backend.es.model.meta.ModelConfig}, so that translation of individual aspects of a search command into
+ * Elasticsearch boolean compound query clauses can be handled in field setter methods on an
+ * atomic level, without the need to actually call all these setters by hand.
+ *
+ * Furthermore, there is a kinda clumsy abstraction for query dependency tree execution which to at
+ * least some degree is capable of emulating JOIN queries.
+ *
+ * @author jhoeper
+ */
+package tla.backend.es.query;

--- a/src/main/java/tla/backend/service/EntityService.java
+++ b/src/main/java/tla/backend/service/EntityService.java
@@ -292,15 +292,6 @@ public abstract class EntityService<T extends Indexable, R extends Elasticsearch
     }
 
     /**
-     * Converts terms aggregations to a map of field value counts.
-     *
-     * @Deprecated
-     */
-    public Map<String, Map<String, Long>> facets(SearchHits<?> hits) {
-        return searchService.extractFacets(hits);
-    }
-
-    /**
      * Extract DTO objects out of a list of searchresults of an entity type.
      */
     public List<D> hitsToDTO(SearchHits<?> hits, Class<D> dtoClass) {
@@ -310,24 +301,6 @@ public abstract class EntityService<T extends Indexable, R extends Elasticsearch
                 dtoClass
             )
         ).collect(Collectors.toList());
-    }
-
-    /**
-     * Takes an Elasticsearch search result and the original page information and search
-     * command, and puts it all into a serializable container ready for return
-     * to the requesting client.
-     * 
-     * TODO: to search service
-     */
-    public SearchResultsWrapper<D> wrapSearchResults(
-        SearchHits<?> hits, Pageable pageable, SearchCommand<D> command
-    ) throws Exception {
-        return new SearchResultsWrapper<D>(
-            hitsToDTO(hits, getDtoClass()),
-            command,
-            pageInfo(hits, pageable),
-            facets(hits)
-        );
     }
 
     /**

--- a/src/main/java/tla/backend/service/EntityService.java
+++ b/src/main/java/tla/backend/service/EntityService.java
@@ -372,11 +372,12 @@ public abstract class EntityService<T extends Indexable, R extends Elasticsearch
         var queryAdapter = this.getSearchCommandAdapter(command);
         ESQueryResult<?> result = searchService.register(queryAdapter).run(page);
         try {
+            result.getAggregations().remove(ESQueryResult.AGGS_ID_IDS);
             var wrapper = new SearchResultsWrapper<D>(
                 hitsToDTO(result.getHits(), this.getDtoClass()),
                 command,
                 result.getPageInfo(),
-                facets(result.getHits())
+                result.getAggregations()
             );
             retrieveRelatedDocs(result).resolve().forEach(
                 relatedObject -> wrapper.addRelated(

--- a/src/main/java/tla/backend/service/SentenceService.java
+++ b/src/main/java/tla/backend/service/SentenceService.java
@@ -1,16 +1,5 @@
 package tla.backend.service;
 
-import static org.elasticsearch.index.query.QueryBuilders.nestedQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
-
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import org.apache.lucene.search.join.ScoreMode;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.search.aggregations.AggregationBuilders;
-import org.elasticsearch.search.aggregations.BucketOrder;
-import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import org.springframework.stereotype.Service;
@@ -26,8 +15,6 @@ import tla.domain.dto.SentenceDto;
 @Service
 @ModelClass(value = SentenceEntity.class, path = "sentence")
 public class SentenceService extends EntityService<SentenceEntity, ElasticsearchRepository<SentenceEntity, String>, SentenceDto> {
-
-    private final static String LEMMA_FREQ_AGG_NAME = "aggr_around_text_id";
 
     @Autowired
     private SentenceRepo repo;
@@ -50,33 +37,6 @@ public class SentenceService extends EntityService<SentenceEntity, Elasticsearch
             super.retrieveReferencedThesaurusEntries(text)
         );
         return relatedDocuments;
-    }
-
-    /**
-     * Count occurrences of the specified lemma in each text.
-     */
-    public Map<String, Long> lemmaFrequencyPerText(String lemmaId) {
-        SearchResponse response = this.searchService.query(
-            SentenceEntity.class,
-            nestedQuery(
-                "tokens",
-                termQuery(
-                    "tokens.lemma.id", lemmaId
-                ),
-                ScoreMode.None
-            ),
-            AggregationBuilders.terms(LEMMA_FREQ_AGG_NAME)
-                .field("context.textId")
-                .order(BucketOrder.count(false))
-                .size(10000000)
-        );
-        Terms frequencies = (Terms) response.getAggregations().asMap().get(LEMMA_FREQ_AGG_NAME);
-        return frequencies.getBuckets().stream().collect(
-            Collectors.toMap(
-                Terms.Bucket::getKeyAsString,
-                Terms.Bucket::getDocCount
-            )
-        );
     }
 
     @Override

--- a/src/main/java/tla/backend/service/component/AttestationTreeBuilder.java
+++ b/src/main/java/tla/backend/service/component/AttestationTreeBuilder.java
@@ -1,0 +1,98 @@
+package tla.backend.service.component;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import lombok.Getter;
+import tla.backend.es.model.Util;
+import tla.backend.es.model.meta.BaseEntity;
+import tla.backend.es.model.meta.Recursable;
+import tla.backend.es.model.parts.ObjectPath;
+import tla.domain.model.meta.Resolvable;
+
+public class AttestationTreeBuilder {
+
+    static class Node {
+        private Set<Node> parents;
+        private Set<Node> children;
+        @Getter
+        private Recursable entity;
+
+        Node(Recursable entity) {
+            this.parents = new HashSet<>();
+            this.children = new HashSet<>();
+            this.entity = entity;
+        }
+
+        void addChild(Node child) {
+            this.children.add(child);
+        }
+
+        void addParent(Node parent) {
+            this.parents.add(parent);
+        }
+
+        boolean isRoot() {
+            return this.parents.isEmpty();
+        }
+
+    }
+
+    private Map<String, Node> nodes;
+
+    public AttestationTreeBuilder(Stream<Recursable> stream) {
+        this.nodes = stream.collect(
+            Collectors.toMap(
+                entity -> ((BaseEntity) entity).getId(),
+                entity -> new Node(entity)
+            )
+        );
+        this.nodes.values().stream().forEach(
+            this::register
+        );
+    }
+
+    public static AttestationTreeBuilder of(Stream<Recursable> entities) {
+        return new AttestationTreeBuilder(entities);
+    }
+
+    private Node getNode(String id) {
+        return this.nodes.getOrDefault(id, null);
+    }
+
+    private void attach(Node node, Node parent) {
+        parent.addChild(node);
+        node.addParent(parent);
+    }
+
+    private Node findClosestAncestor(ObjectPath path) {
+        for (Resolvable segment : Util.reverse(path)) {
+            var node = getNode(segment.getId());
+            if (node != null) {
+                return node;
+            }
+        }
+        return null;
+    }
+
+    private void register(Node node) {
+        if (node.getEntity().getPaths() != null) {
+            for (ObjectPath path : node.getEntity().getPaths()) {
+                var parent = findClosestAncestor(path);
+                if (parent != null) {
+                    attach(node, parent);
+                }
+            }
+        }
+    }
+
+    public Stream<Node> getRoots() {
+        return this.nodes.values().stream().filter(
+            Node::isRoot
+        );
+    }
+
+}

--- a/src/main/java/tla/backend/service/component/EntityRetrieval.java
+++ b/src/main/java/tla/backend/service/component/EntityRetrieval.java
@@ -40,6 +40,15 @@ public class EntityRetrieval {
         }
 
         /**
+         * creates a new bulk entity resolver instance and initialize it
+         * with given stream of object reference items to be resolved to actual
+         * entities.
+         */
+        public static BulkEntityResolver of(Stream<? extends Resolvable> references) {
+            return BulkEntityResolver.of(references.collect(Collectors.toList()));
+        }
+
+        /**
          * Take all objectreferences in an entity's <code>relations</code> map and feeds them into
          * a new {@link BulkEntityResolver} instance.
          */
@@ -126,13 +135,22 @@ public class EntityRetrieval {
         }
 
         /**
-         * Retrieve referenced object from respective ES repositories.
+         * Retrieve referenced object from respective ES indices.
          */
         public Collection<Indexable> resolve() {
+            return this.stream().collect(
+                Collectors.toList()
+            );
+        }
+
+        /**
+         * Resolve as stream, i.e. retrieve all queued objects from respective ES indices.
+         *
+         * @see #resolve()
+         */
+        public Stream<Indexable> stream() {
             return this.refs.entrySet().stream().flatMap(
                 e -> this.resolve(e.getKey(), e.getValue())
-            ).collect(
-                Collectors.toList()
             );
         }
 

--- a/src/main/java/tla/backend/service/search/SearchService.java
+++ b/src/main/java/tla/backend/service/search/SearchService.java
@@ -32,6 +32,8 @@ import tla.backend.es.query.TLAQueryBuilder.QueryDependency;
 @Service
 public class SearchService {
 
+    public final static String AGG_ID_DATES = "date.date.date";
+
     /**
      * Execute search command query adapter and its dependencies.
      */
@@ -124,25 +126,17 @@ public class SearchService {
         AggregationBuilder aggsBuilder
     ) {
         String index = operations.getIndexCoordinatesFor(entityClass).getIndexName();
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .query(queryBuilder);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(queryBuilder);
         if (aggsBuilder != null) {
             searchSourceBuilder = searchSourceBuilder.aggregation(aggsBuilder);
         }
-        SearchRequest request = new SearchRequest()
-            .indices(
-                index
-            )
-            .source(
-                searchSourceBuilder
-            );
-        SearchResponse response = null;
+        SearchRequest request = new SearchRequest().indices(index).source(
+            searchSourceBuilder
+        );
         try {
-            response = restClient
-                .search(
-                    request,
-                    RequestOptions.DEFAULT
-                );
+            return restClient.search(
+                request, RequestOptions.DEFAULT
+            );
         } catch (Exception e) {
             log.error(
                 String.format(
@@ -152,7 +146,7 @@ public class SearchService {
                 e
             );
         }
-        return response;
+        return null;
     }
 
     /**

--- a/src/test/java/tla/backend/es/model/UtilTest.java
+++ b/src/test/java/tla/backend/es/model/UtilTest.java
@@ -1,0 +1,18 @@
+package tla.backend.es.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class UtilTest {
+
+    @Test
+    void reverseList() {
+        var list = List.of(1, 2, 3, 4);
+        var reverse = Util.reverse(list);
+        assertEquals(List.of(4, 3, 2, 1), reverse, "inverted list should be in inverse order");
+    }
+
+}

--- a/src/test/java/tla/backend/es/model/meta/MappingTest.java
+++ b/src/test/java/tla/backend/es/model/meta/MappingTest.java
@@ -11,11 +11,14 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.modelmapper.ModelMapper;
 
+import tla.backend.Util;
+import tla.backend.es.model.ThsEntryEntity;
 import tla.backend.es.query.SentenceSearchQueryBuilder;
 import tla.backend.es.query.TextSearchQueryBuilder;
 import tla.domain.command.PassportSpec;
 import tla.domain.command.SentenceSearch;
 import tla.domain.command.TextSearch;
+import tla.domain.dto.ThsEntryDto;
 
 @TestInstance(Lifecycle.PER_CLASS)
 public class MappingTest {
@@ -52,6 +55,15 @@ public class MappingTest {
         SentenceSearch cmd = new SentenceSearch();
         var qb = modelMapper.map(cmd, SentenceSearchQueryBuilder.class);
         assertNotNull(qb);
+    }
+
+    @Test
+    void objectReferenceEquality() throws Exception {
+        ThsEntryEntity ths = Util.loadSampleFile(ThsEntryEntity.class, "E7YEQAEKZVEJ5PX7WKOXY2QEEM");
+        ThsEntryDto dto = modelMapper.map(ths, ThsEntryDto.class);
+        tla.domain.model.ObjectReference dtoRef = tla.domain.model.ObjectReference.from(dto);
+        tla.domain.model.ObjectReference refDto = ths.toDTOReference();
+        assertEquals(refDto, dtoRef, "DTO-style object reference extracted from entity should equal object reference extracted from DTO");
     }
 
 }

--- a/src/test/java/tla/backend/es/model/meta/TreeTest.java
+++ b/src/test/java/tla/backend/es/model/meta/TreeTest.java
@@ -1,0 +1,54 @@
+package tla.backend.es.model.meta;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import lombok.Getter;
+import lombok.Setter;
+import tla.backend.es.model.parts.ObjectPath;
+import tla.backend.es.model.parts.ObjectReference;
+import tla.domain.model.meta.BTSeClass;
+
+
+public class TreeTest {
+
+    @Getter
+    @Setter
+    @BTSeClass("eclass")
+    static class TreeTestEntity extends BaseEntity implements Recursable {
+        ObjectPath[] paths;
+        static TreeTestEntity of(String id, String name, String type) {
+            var entity = new TreeTestEntity();
+            entity.setId(id);
+            entity.setType(type);
+            entity.setName(name);
+            return entity;
+        }
+    }
+
+
+    @Test
+    void hierarchicEntities() {
+        var parent = TreeTestEntity.of("1", "parent", "type");
+        var child = TreeTestEntity.of("2", "child", "type");
+        child.setPaths(
+            new ObjectPath[]{
+                ObjectPath.of(
+                    ObjectReference.builder().id(
+                        parent.getId()
+                    ).name(
+                        parent.getName()
+                    ).type(
+                        parent.getType()
+                    ).eclass(
+                        parent.getEclass()
+                    ).build()
+                )
+            }
+        );
+        assertTrue(parent.isAncestorOf(child));
+        assertTrue(child.hasAncestor(parent));
+        assertFalse(child.isAncestorOf(parent));
+    }
+}

--- a/src/test/java/tla/backend/es/query/QueryResultTest.java
+++ b/src/test/java/tla/backend/es/query/QueryResultTest.java
@@ -1,0 +1,49 @@
+package tla.backend.es.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.SearchHitsImpl;
+import org.springframework.data.elasticsearch.core.TotalHitsRelation;
+
+import tla.backend.es.model.LemmaEntity;
+
+public class QueryResultTest {
+
+    final List<? extends SearchHit<LemmaEntity>> HITS_MOCK = new ArrayList<>();
+
+    @Test
+    void paginationTest_hitCountMultipleOfPagesize() {
+        final int pages = 2;
+        
+        SearchHits<?> searchHits = new SearchHitsImpl<>(
+            pages * ESQueryResult.SEARCH_RESULT_PAGE_SIZE,
+            TotalHitsRelation.EQUAL_TO, 10f, null, HITS_MOCK, null
+        );
+        Pageable page = PageRequest.of(0, ESQueryResult.SEARCH_RESULT_PAGE_SIZE);
+        assertEquals(
+            pages, ESQueryResult.pageInfo(searchHits, page).getTotalPages(), "n times page size results fit in n pages"
+        );
+    }
+
+    @Test
+    void paginationTest_singleResultOnLastPage() {
+        final int pages = 2;
+        SearchHits<?> searchHits = new SearchHitsImpl<>(
+            pages * ESQueryResult.SEARCH_RESULT_PAGE_SIZE + 1,
+            TotalHitsRelation.EQUAL_TO, 10f, null, HITS_MOCK, null
+        );
+        Pageable page = PageRequest.of(0, ESQueryResult.SEARCH_RESULT_PAGE_SIZE);
+        assertEquals(
+            pages + 1, ESQueryResult.pageInfo(searchHits, page).getTotalPages(), "n times page size results fit in n + 1 pages"
+        );
+    }
+
+}

--- a/src/test/java/tla/backend/search/SearchTest.java
+++ b/src/test/java/tla/backend/search/SearchTest.java
@@ -29,6 +29,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import tla.backend.es.model.LemmaEntity;
 import tla.backend.es.model.meta.ModelConfig;
+import tla.backend.es.query.ESQueryResult;
 import tla.backend.es.repo.RepoConfig;
 import tla.backend.es.repo.RepoPopulator;
 import tla.backend.service.EntityService;
@@ -42,7 +43,7 @@ import tla.domain.dto.extern.SearchResultsWrapper;
 @TestInstance(Lifecycle.PER_CLASS)
 public class SearchTest {
 
-    public static final Pageable PAGE_1 = PageRequest.of(0, 20);
+    public static final Pageable PAGE_1 = PageRequest.of(0, ESQueryResult.SEARCH_RESULT_PAGE_SIZE);
 
     @Configuration
     @Import({RepoConfig.class, ModelConfig.class})

--- a/src/test/java/tla/backend/service/component/AttestationTreeBuilderTest.java
+++ b/src/test/java/tla/backend/service/component/AttestationTreeBuilderTest.java
@@ -2,6 +2,8 @@ package tla.backend.service.component;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -12,15 +14,17 @@ import tla.backend.Util;
 import tla.backend.es.model.ThsEntryEntity;
 import tla.backend.es.model.meta.BaseEntity;
 import tla.backend.es.model.meta.Recursable;
+import tla.domain.model.extern.AttestedTimespan;
 
 public class AttestationTreeBuilderTest {
 
     @Test
     @DisplayName("sample of entities should be arranged according to hierarchy")
-    void testAttestationTree() throws Exception {
+    void testTreeReconstruction() throws Exception {
         Stream<Recursable> thsEntries = Stream.of(
             Util.loadSampleFile(ThsEntryEntity.class, "E7YEQAEKZVEJ5PX7WKOXY2QEEM"),
-            Util.loadSampleFile(ThsEntryEntity.class, "N673TBXEGJDDBO6B6DZXKT64YQ")
+            Util.loadSampleFile(ThsEntryEntity.class, "N673TBXEGJDDBO6B6DZXKT64YQ"),
+            Util.loadSampleFile(ThsEntryEntity.class, "4SJRB25AURBUZMSZBBXRRHDO3A")
         );
         AttestationTreeBuilder treeBuilder = AttestationTreeBuilder.of(thsEntries);
         var roots = treeBuilder.getRoots().collect(Collectors.toList());
@@ -31,6 +35,28 @@ public class AttestationTreeBuilderTest {
                 ((BaseEntity) roots.get(0).getEntity()).getId(),
                 "entity highest up in hierarchy should be root node"
             )
+        );
+    }
+
+    @Test
+    @DisplayName("reconstructed hierarchic entity tree should translate to nested attestation objects")
+    void testAttestationTree() throws Exception {
+        Stream<Recursable> thsEntries = Stream.of(
+            Util.loadSampleFile(ThsEntryEntity.class, "E7YEQAEKZVEJ5PX7WKOXY2QEEM"),
+            Util.loadSampleFile(ThsEntryEntity.class, "N673TBXEGJDDBO6B6DZXKT64YQ"),
+            Util.loadSampleFile(ThsEntryEntity.class, "4SJRB25AURBUZMSZBBXRRHDO3A")
+        );
+        Map<String, Long> counts = Map.of(
+            "E7YEQAEKZVEJ5PX7WKOXY2QEEM", 5L,
+            "N673TBXEGJDDBO6B6DZXKT64YQ", 7L,
+            "4SJRB25AURBUZMSZBBXRRHDO3A", 11L
+        );
+        AttestationTreeBuilder treeBuilder = AttestationTreeBuilder.of(thsEntries);
+        List<AttestedTimespan> attestations = treeBuilder.counts(counts).resolve();
+        assertAll("nested attestations should resemble entity tree reconstruction",
+            () -> assertEquals(1, attestations.size(), "only 1 attestation object on root level"),
+            () -> assertEquals(2, attestations.get(0).getContains().size(), "root attestation should have 2 children"),
+            () -> assertEquals(7L, attestations.get(0).getAttestations().getCount(), "attestation count should have been set according to map passed")
         );
     }
 

--- a/src/test/java/tla/backend/service/component/AttestationTreeBuilderTest.java
+++ b/src/test/java/tla/backend/service/component/AttestationTreeBuilderTest.java
@@ -1,0 +1,37 @@
+package tla.backend.service.component;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import tla.backend.Util;
+import tla.backend.es.model.ThsEntryEntity;
+import tla.backend.es.model.meta.BaseEntity;
+import tla.backend.es.model.meta.Recursable;
+
+public class AttestationTreeBuilderTest {
+
+    @Test
+    @DisplayName("sample of entities should be arranged according to hierarchy")
+    void testAttestationTree() throws Exception {
+        Stream<Recursable> thsEntries = Stream.of(
+            Util.loadSampleFile(ThsEntryEntity.class, "E7YEQAEKZVEJ5PX7WKOXY2QEEM"),
+            Util.loadSampleFile(ThsEntryEntity.class, "N673TBXEGJDDBO6B6DZXKT64YQ")
+        );
+        AttestationTreeBuilder treeBuilder = AttestationTreeBuilder.of(thsEntries);
+        var roots = treeBuilder.getRoots().collect(Collectors.toList());
+        assertAll("entities should be organized according to hierarchic relations",
+            () -> assertEquals(1, roots.size(), "only 1 root"),
+            () -> assertEquals(
+                "N673TBXEGJDDBO6B6DZXKT64YQ",
+                ((BaseEntity) roots.get(0).getEntity()).getId(),
+                "entity highest up in hierarchy should be root node"
+            )
+        );
+    }
+
+}

--- a/src/test/resources/sample/ths/4SJRB25AURBUZMSZBBXRRHDO3A.json
+++ b/src/test/resources/sample/ths/4SJRB25AURBUZMSZBBXRRHDO3A.json
@@ -1,0 +1,137 @@
+{
+ "editors": {
+   "author": "Altägyptisches Wörterbuch",
+   "contributors": [
+     "L. Popko"
+   ],
+   "created": "2015-06-26",
+   "updated": "2020-05-22"
+ },
+ "externalReferences": {
+   "aaew": [
+     {
+       "id": "9/54"
+     }
+   ],
+   "thot": [
+     {
+       "id": "thot-171"
+     }
+   ]
+ },
+ "hash": "q6z47t",
+ "id": "4SJRB25AURBUZMSZBBXRRHDO3A",
+ "name": "Djedefre",
+ "passport": {
+   "synonyms": [
+     {
+       "synonym_group": [
+         {
+           "language": [
+             "en"
+           ],
+           "synonym": [
+             "Djedefre"
+           ]
+         },
+         {
+           "language": [
+             "fr"
+           ],
+           "synonym": [
+             "Djedefrê"
+           ]
+         }
+       ]
+     }
+   ],
+   "thesaurus": [
+     {
+       "main_group": [
+         {
+           "old_id": [
+             "54"
+           ],
+           "old_thesaurus_number": [
+             "9"
+           ],
+           "termsort": [
+             "djedefre"
+           ]
+         }
+       ]
+     }
+   ],
+   "thesaurus_date": [
+     {
+       "main_group": [
+         {
+           "beginning": [
+             "-2566"
+           ],
+           "end": [
+             "-2558"
+           ],
+           "reference": [
+             "Shaw, I. (Hg.), The Oxford History of Ancient Egypt, Oxford 2000, 482."
+           ]
+         }
+       ]
+     }
+   ]
+ },
+ "paths": [
+   [
+     {
+       "eclass": "BTSThsEntry",
+       "id": "MXWX4WG43ZHI7D4RLTGK3IBGXY",
+       "name": "9 = Datierungen",
+       "type": "date"
+     },
+     {
+       "eclass": "BTSThsEntry",
+       "id": "DUVGWT7GSRCKDM5LFTGU6MZ3GY",
+       "name": "(Epochen und Dynastien)",
+       "type": "date"
+     },
+     {
+       "eclass": "BTSThsEntry",
+       "id": "N673TBXEGJDDBO6B6DZXKT64YQ",
+       "name": "Pharaonische Zeit",
+       "type": "date"
+     },
+     {
+       "eclass": "BTSThsEntry",
+       "id": "DBDBZEFDGZGGBMERHVKJ6PMPHQ",
+       "name": "Altes Reich",
+       "type": "date"
+     },
+     {
+       "eclass": "BTSThsEntry",
+       "id": "WCVSHAEC7ZA4FKQOWR4E2GC6OM",
+       "name": "4. Dynastie",
+       "type": "date"
+     }
+   ]
+ ],
+ "relations": {
+   "partOf": [
+     {
+       "eclass": "BTSThsEntry",
+       "id": "WCVSHAEC7ZA4FKQOWR4E2GC6OM",
+       "name": "4. Dynastie",
+       "type": "date"
+     }
+   ]
+ },
+ "revisionState": "published",
+ "translations": {
+   "en": [
+     "Djedefre"
+   ],
+   "fr": [
+     "Djedefrê"
+   ]
+ },
+ "type": "date"
+}

--- a/src/test/resources/sample/ths/N673TBXEGJDDBO6B6DZXKT64YQ.json
+++ b/src/test/resources/sample/ths/N673TBXEGJDDBO6B6DZXKT64YQ.json
@@ -1,0 +1,147 @@
+{
+	"editors": {
+			"author": "L. Popko",
+			"created": "2020-06-12",
+			"updated": "2020-06-12"
+	},
+	"externalReferences": {
+			"thot": [
+					{
+							"id": "thot-141"
+					}
+			]
+	},
+	"hash": "ch0sql",
+	"id": "N673TBXEGJDDBO6B6DZXKT64YQ",
+	"name": "Pharaonische Zeit",
+	"passport": {
+			"synonyms": [
+					{
+							"synonym_group": [
+									{
+											"language": [
+													"en"
+											],
+											"synonym": [
+													"Pharaonic Period"
+											]
+									},
+									{
+											"language": [
+													"fr"
+											],
+											"synonym": [
+													"Période Pharaonique"
+											]
+									}
+							]
+					}
+			],
+			"thesaurus_date": [
+					{
+							"main_group": [
+									{
+											"beginning": [
+													"-3150"
+											],
+											"end": [
+													"-332"
+											]
+									}
+							]
+					}
+			]
+	},
+	"paths": [
+			[
+					{
+							"eclass": "BTSThsEntry",
+							"id": "MXWX4WG43ZHI7D4RLTGK3IBGXY",
+							"name": "9 = Datierungen",
+							"type": "date"
+					},
+					{
+							"eclass": "BTSThsEntry",
+							"id": "DUVGWT7GSRCKDM5LFTGU6MZ3GY",
+							"name": "(Epochen und Dynastien)",
+							"type": "date"
+					}
+			]
+	],
+	"relations": {
+			"contains": [
+					{
+							"eclass": "BTSThsEntry",
+							"id": "3GGZCLNRQVF6PAEQA6LCFBNE6M",
+							"name": "Zweite Zwischenzeit",
+							"type": "date"
+					},
+					{
+							"eclass": "BTSThsEntry",
+							"id": "7G4I7VLRZFCZFBDWXWJBCSPIPI",
+							"name": "11. Dynastie (Gesamtzeitraum)",
+							"type": "date"
+					},
+					{
+							"eclass": "BTSThsEntry",
+							"id": "BILVGTX4DVEERA2TQ2DFPYYTK4",
+							"name": "Frühdynastische Zeit",
+							"type": "date"
+					},
+					{
+							"eclass": "BTSThsEntry",
+							"id": "DBDBZEFDGZGGBMERHVKJ6PMPHQ",
+							"name": "Altes Reich",
+							"type": "date"
+					},
+					{
+							"eclass": "BTSThsEntry",
+							"id": "JS32JKX2CNG25GZ3B6MGYMDU4I",
+							"name": "Dritte Zwischenzeit",
+							"type": "date"
+					},
+					{
+							"eclass": "BTSThsEntry",
+							"id": "MM4QYACJOJCCLJWBD6VAX2FLKE",
+							"name": "Mittleres Reich",
+							"type": "date"
+					},
+					{
+							"eclass": "BTSThsEntry",
+							"id": "QBN55U2GTFA27GHK3IACBTMK2U",
+							"name": "Erste Zwischenzeit",
+							"type": "date"
+					},
+					{
+							"eclass": "BTSThsEntry",
+							"id": "UGTUTKXZHBDYLG7YJZ5AGOJXQY",
+							"name": "Spätzeit",
+							"type": "date"
+					},
+					{
+							"eclass": "BTSThsEntry",
+							"id": "WX32K2TQTRETLDX2IO6SL5DDBU",
+							"name": "Neues Reich",
+							"type": "date"
+					}
+			],
+			"partOf": [
+					{
+							"eclass": "BTSThsEntry",
+							"id": "DUVGWT7GSRCKDM5LFTGU6MZ3GY",
+							"name": "(Epochen und Dynastien)",
+							"type": "date"
+					}
+			]
+	},
+	"revisionState": "published",
+	"translations": {
+			"en": [
+					"Pharaonic Period"
+			],
+			"fr": [
+					"Période Pharaonique"
+			]
+	},
+	"type": "date"
+}

--- a/src/test/resources/sample/ths/N673TBXEGJDDBO6B6DZXKT64YQ.json
+++ b/src/test/resources/sample/ths/N673TBXEGJDDBO6B6DZXKT64YQ.json
@@ -1,147 +1,147 @@
 {
-	"editors": {
-			"author": "L. Popko",
-			"created": "2020-06-12",
-			"updated": "2020-06-12"
-	},
-	"externalReferences": {
-			"thot": [
-					{
-							"id": "thot-141"
-					}
-			]
-	},
-	"hash": "ch0sql",
-	"id": "N673TBXEGJDDBO6B6DZXKT64YQ",
-	"name": "Pharaonische Zeit",
-	"passport": {
-			"synonyms": [
-					{
-							"synonym_group": [
-									{
-											"language": [
-													"en"
-											],
-											"synonym": [
-													"Pharaonic Period"
-											]
-									},
-									{
-											"language": [
-													"fr"
-											],
-											"synonym": [
-													"Période Pharaonique"
-											]
-									}
-							]
-					}
-			],
-			"thesaurus_date": [
-					{
-							"main_group": [
-									{
-											"beginning": [
-													"-3150"
-											],
-											"end": [
-													"-332"
-											]
-									}
-							]
-					}
-			]
-	},
-	"paths": [
-			[
-					{
-							"eclass": "BTSThsEntry",
-							"id": "MXWX4WG43ZHI7D4RLTGK3IBGXY",
-							"name": "9 = Datierungen",
-							"type": "date"
-					},
-					{
-							"eclass": "BTSThsEntry",
-							"id": "DUVGWT7GSRCKDM5LFTGU6MZ3GY",
-							"name": "(Epochen und Dynastien)",
-							"type": "date"
-					}
-			]
-	],
-	"relations": {
-			"contains": [
-					{
-							"eclass": "BTSThsEntry",
-							"id": "3GGZCLNRQVF6PAEQA6LCFBNE6M",
-							"name": "Zweite Zwischenzeit",
-							"type": "date"
-					},
-					{
-							"eclass": "BTSThsEntry",
-							"id": "7G4I7VLRZFCZFBDWXWJBCSPIPI",
-							"name": "11. Dynastie (Gesamtzeitraum)",
-							"type": "date"
-					},
-					{
-							"eclass": "BTSThsEntry",
-							"id": "BILVGTX4DVEERA2TQ2DFPYYTK4",
-							"name": "Frühdynastische Zeit",
-							"type": "date"
-					},
-					{
-							"eclass": "BTSThsEntry",
-							"id": "DBDBZEFDGZGGBMERHVKJ6PMPHQ",
-							"name": "Altes Reich",
-							"type": "date"
-					},
-					{
-							"eclass": "BTSThsEntry",
-							"id": "JS32JKX2CNG25GZ3B6MGYMDU4I",
-							"name": "Dritte Zwischenzeit",
-							"type": "date"
-					},
-					{
-							"eclass": "BTSThsEntry",
-							"id": "MM4QYACJOJCCLJWBD6VAX2FLKE",
-							"name": "Mittleres Reich",
-							"type": "date"
-					},
-					{
-							"eclass": "BTSThsEntry",
-							"id": "QBN55U2GTFA27GHK3IACBTMK2U",
-							"name": "Erste Zwischenzeit",
-							"type": "date"
-					},
-					{
-							"eclass": "BTSThsEntry",
-							"id": "UGTUTKXZHBDYLG7YJZ5AGOJXQY",
-							"name": "Spätzeit",
-							"type": "date"
-					},
-					{
-							"eclass": "BTSThsEntry",
-							"id": "WX32K2TQTRETLDX2IO6SL5DDBU",
-							"name": "Neues Reich",
-							"type": "date"
-					}
-			],
-			"partOf": [
-					{
-							"eclass": "BTSThsEntry",
-							"id": "DUVGWT7GSRCKDM5LFTGU6MZ3GY",
-							"name": "(Epochen und Dynastien)",
-							"type": "date"
-					}
-			]
-	},
-	"revisionState": "published",
-	"translations": {
-			"en": [
-					"Pharaonic Period"
-			],
-			"fr": [
-					"Période Pharaonique"
-			]
-	},
-	"type": "date"
+ "editors": {
+   "author": "L. Popko",
+   "created": "2020-06-12",
+   "updated": "2020-06-12"
+ },
+ "externalReferences": {
+   "thot": [
+     {
+       "id": "thot-141"
+     }
+   ]
+ },
+ "hash": "ch0sql",
+ "id": "N673TBXEGJDDBO6B6DZXKT64YQ",
+ "name": "Pharaonische Zeit",
+ "passport": {
+   "synonyms": [
+     {
+       "synonym_group": [
+         {
+           "language": [
+             "en"
+           ],
+           "synonym": [
+             "Pharaonic Period"
+           ]
+         },
+         {
+           "language": [
+             "fr"
+           ],
+           "synonym": [
+             "Période Pharaonique"
+           ]
+         }
+       ]
+     }
+   ],
+   "thesaurus_date": [
+     {
+       "main_group": [
+         {
+           "beginning": [
+             "-3150"
+           ],
+           "end": [
+             "-332"
+           ]
+         }
+       ]
+     }
+   ]
+ },
+ "paths": [
+   [
+     {
+       "eclass": "BTSThsEntry",
+       "id": "MXWX4WG43ZHI7D4RLTGK3IBGXY",
+       "name": "9 = Datierungen",
+       "type": "date"
+     },
+     {
+       "eclass": "BTSThsEntry",
+       "id": "DUVGWT7GSRCKDM5LFTGU6MZ3GY",
+       "name": "(Epochen und Dynastien)",
+       "type": "date"
+     }
+   ]
+ ],
+ "relations": {
+   "contains": [
+     {
+       "eclass": "BTSThsEntry",
+       "id": "3GGZCLNRQVF6PAEQA6LCFBNE6M",
+       "name": "Zweite Zwischenzeit",
+       "type": "date"
+     },
+     {
+       "eclass": "BTSThsEntry",
+       "id": "7G4I7VLRZFCZFBDWXWJBCSPIPI",
+       "name": "11. Dynastie (Gesamtzeitraum)",
+       "type": "date"
+     },
+     {
+       "eclass": "BTSThsEntry",
+       "id": "BILVGTX4DVEERA2TQ2DFPYYTK4",
+       "name": "Frühdynastische Zeit",
+       "type": "date"
+     },
+     {
+       "eclass": "BTSThsEntry",
+       "id": "DBDBZEFDGZGGBMERHVKJ6PMPHQ",
+       "name": "Altes Reich",
+       "type": "date"
+     },
+     {
+       "eclass": "BTSThsEntry",
+       "id": "JS32JKX2CNG25GZ3B6MGYMDU4I",
+       "name": "Dritte Zwischenzeit",
+       "type": "date"
+     },
+     {
+       "eclass": "BTSThsEntry",
+       "id": "MM4QYACJOJCCLJWBD6VAX2FLKE",
+       "name": "Mittleres Reich",
+       "type": "date"
+     },
+     {
+       "eclass": "BTSThsEntry",
+       "id": "QBN55U2GTFA27GHK3IACBTMK2U",
+       "name": "Erste Zwischenzeit",
+       "type": "date"
+     },
+     {
+       "eclass": "BTSThsEntry",
+       "id": "UGTUTKXZHBDYLG7YJZ5AGOJXQY",
+       "name": "Spätzeit",
+       "type": "date"
+     },
+     {
+       "eclass": "BTSThsEntry",
+       "id": "WX32K2TQTRETLDX2IO6SL5DDBU",
+       "name": "Neues Reich",
+       "type": "date"
+     }
+   ],
+   "partOf": [
+     {
+       "eclass": "BTSThsEntry",
+       "id": "DUVGWT7GSRCKDM5LFTGU6MZ3GY",
+       "name": "(Epochen und Dynastien)",
+       "type": "date"
+     }
+   ]
+ },
+ "revisionState": "published",
+ "translations": {
+   "en": [
+     "Pharaonic Period"
+   ],
+   "fr": [
+     "Période Pharaonique"
+   ]
+ },
+ "type": "date"
 }


### PR DESCRIPTION
Add interface `Recursable` [75383143c2191d541803] for entities in hierarchic structures to implement (i.e. thesaurus entries, text and text corpus object entites). Add nested attestation tree builder [8901a1f11817e5] putting selection of recursable entities into tree structure according to the global tree they are located within. Use it to nest thesaurus entries representing time periods for which lemma occurrences can be attested retrieved by using joined dependency queries and accumulated aggregations [ff8e6002aaa52, e79a5a6, 722f52c]

Also fixes https://github.com/thesaurus-linguae-aegyptiae/tla-web/issues/52 [aba21a8]