### PR TITLE
prevent gradle from installing plugins from jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 buildscript {
   repositories {
+    // maybe also add gradle's maven repo for plugins as well, cf. https://github.com/JKatzwinkel/tla-es/pull/82
+    // and more specifically https://github.com/gradle/gradle/issues/22864#issuecomment-1327978524
     mavenCentral()
   }
 }


### PR DESCRIPTION
[jcenter will eventually shut down](https://blog.gradle.org/jcenter-shutdown). Many gradle plugins even on maven central still [seem to have their dependencies resolved against jcenter](https://github.com/gradle/plugin-portal-requests/issues/171). Although jcenter is supposed to remain up as a read-only repository, there has been an effective outage now due to their SSL certificate having expired.  It [didn't take terribly long](https://github.com/gradle/gradle/issues/22864#issuecomment-1328003539) for them to roll out the new certificate, however they might not necessarily [have keeping the repo up as a priority anymore](https://github.com/gradle/plugin-portal-requests/issues/165), and [the same problem](https://github.com/spring-projects/spring-boot/issues/33368#issuecomment-1327965629) might arise again once the new certificate expires in 1 year's time:

```bash
  > openssl s_client -connect jcenter.bintray.com:443 | openssl x509 -noout -dates 
  depth=2 C = US, O = DigiCert Inc, OU = www.digicert.com, CN = DigiCert Global Root CA
  verify return:1
  depth=1 C = US, O = "DigiCert, Inc.", CN = GeoTrust Global TLS RSA4096 SHA256 2022 CA1
  verify return:1
  depth=0 CN = *.bintray.com
  verify return:1
  notBefore=Nov 14 00:00:00 2022 GMT
  notAfter=Nov  9 23:59:59 2023 GMT
```

considering this, it might not harm to just get it over with now without the delay. The workaround is described in e.g. spring-projects/spring-boot#33368, gradle/gradle#22864, and gradle/plugin-portal-requests#171:

```groovy
  buildscript {
    repositories {
      mavenCentral()
    }
  }
```

in case any of the [quirks mentioned here](https://github.com/gradle/gradle/issues/22864#issuecomment-1327978524) manifest at some point, then Gradle's own maven repo for plugins could be included with the following module metadata configuration as shown in the linked issue comment:

```groovy
  buildscript {
    repositories {
      mavenCentral()
      maven {
        url 'https://plugins.gradle.org/m2'
        metadataSources {
          ignoreGradleMetadataRedirection()
          mavenPom()
          artifact()
        }
      }
    }
  }
```