### PR TITLE
rm obsolete findAllById query workaround

### DIFF
--- a/src/main/java/tla/backend/es/repo/custom/EntityRepo.java
+++ b/src/main/java/tla/backend/es/repo/custom/EntityRepo.java
@@ -5,10 +5,4 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 
 import tla.backend.es.model.meta.Indexable;
 
-public interface EntityRepo<T extends Indexable, ID> extends ElasticsearchRepository<T, ID> {
-
-    @Override
-    @Query("{\"ids\": {\"values\": ?0 }}")
-    Iterable<T> findAllById(Iterable<ID> ids);
-
-}
+public interface EntityRepo<T extends Indexable, ID> extends ElasticsearchRepository<T, ID> {}


### PR DESCRIPTION
the issue making this workaround (introduced in 31ae5aad1a8ab69f034e5272865d8214f43434ef) necessary has long been fixed.