### PR TITLE
Gradle 8.3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,9 +8,6 @@ docker-compose.yml
 .gitattributes
 .github
 .gitignore
-.gradle
-gradle
-gradlew
 gradlew.bat
 .project
 README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM gradle:8.2.1-jdk17 AS build
+FROM openjdk:20-jdk-slim-bullseye AS build
 
-COPY --chown=gradle:gradle . /home/gradle/tla
+COPY . /home/gradle/tla
 WORKDIR /home/gradle/tla
 
-RUN gradle bootJar --no-daemon && \
+RUN ./gradlew bootJar --no-daemon && \
     mv build/libs/*.jar bin/run/tla-backend.jar
 
 
-FROM openjdk:22-jdk-slim-bookworm
+FROM openjdk:20-jdk-slim-bullseye
 
 RUN mkdir /app
 RUN apt-get update && apt-get install -y wget

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- upgrade gradle wrapper to 8.3
- use gradle wrapper in docker build image instead of using `gradle:` image
- downgrade base image to java 20/debian 11